### PR TITLE
Smaller summary click area

### DIFF
--- a/app/Lines/TreeRow.tsx
+++ b/app/Lines/TreeRow.tsx
@@ -297,20 +297,6 @@ function Props({ props }: { props: JsonObject }) {
     return null;
   }
 
-  // Only show props inline if there is just one prop
-  if (
-    rootProps.length === 1 &&
-    // Long props should break the row
-    String(props[rootProps[0]]).length < 80
-  ) {
-    return (
-      <>
-        {" "}
-        <Prop propKey={rootProps[0]} value={props[rootProps[0]]} />
-      </>
-    );
-  }
-
   return (
     <div className="pl-[3ch]">
       {rootProps


### PR DESCRIPTION
The `<summary>` element includes all of the props currently, which makes props inside of components unclickable.

Example: Hovering `<$L10>` shows that `<$L11` is not clickable.

<img width="1194" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/0e4db219-75b8-4660-9c6c-5f80227dc5cc">

After:
<img width="1219" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/f8f33eb9-0bda-43e1-be68-522735490f22">
