### PR TITLE
Make client reference schema looser

### DIFF
--- a/app/Lines/ImportLine.tsx
+++ b/app/Lines/ImportLine.tsx
@@ -1,11 +1,13 @@
 import { z } from "zod";
 
+const stringOrNumber = z.union([z.string(), z.number()]);
+
 const schema = z
   .object({
-    async: z.boolean(),
-    id: z.string(),
+    async: z.boolean().optional(),
+    id: stringOrNumber,
     name: z.string(),
-    chunks: z.array(z.string()),
+    chunks: z.array(stringOrNumber),
   })
   .strict();
 


### PR DESCRIPTION
Some older versions of react-server-dom-webpack seem to generate client references that looks like this:

```
  "file:///SOME_PATH.js": {
    "id": 857,
    "chunks": [
      "main"
    ],
    "name": "*"
  }
```

the `id` is a number, not a string, and the `async` field is missing. Might as well support it