### PR TITLE
Improve TreeLine text rendering

### DIFF
--- a/app/Lines/TreeLine.tsx
+++ b/app/Lines/TreeLine.tsx
@@ -12,6 +12,9 @@ import { ErrorBoundary } from "react-error-boundary";
 import { GenericErrorBoundaryFallback } from "../GenericErrorBoundaryFallback";
 import { TabContext } from "../TabContext";
 import { PayloadContext } from "../PayloadContext";
+import { JetBrains_Mono } from "next/font/google";
+
+const jetBrainsMono = JetBrains_Mono({ subsets: ["latin-ext"] });
 
 export const TYPE_OTHER = "TYPE_OTHER";
 export const TYPE_COMPONENT = "TYPE_COMPONENT";
@@ -50,7 +53,7 @@ export function TreeLine({ data }: { data: string }) {
   const json = JSON.parse(data);
 
   return (
-    <div>
+    <div className={`${jetBrainsMono.className} text-sm`}>
       <Node value={json} />
     </div>
   );
@@ -101,9 +104,7 @@ function JSContainer({ children }: { children: ReactNode }) {
       <Blue>
         <LeftCurlyBrace />
       </Blue>
-      <code className="break-all whitespace-break-spaces text-sm">
-        {children}
-      </code>
+      <code className="break-all whitespace-break-spaces">{children}</code>
 
       <Blue>
         <RightCurlyBrace />
@@ -117,7 +118,7 @@ const ObjectContext = createContext(false);
 function JSObjectValue({ value }: { value: JsonObject }) {
   return (
     <JSContainer>
-      <div className="flex flex-col pl-4">
+      <div className="flex flex-col pl-[2ch]">
         {Object.entries(value).map(([entryKey, entryValue], i) => {
           return (
             <span key={entryKey}>
@@ -242,7 +243,7 @@ function NodeArray({ values }: { values: JsonValue[] | readonly JsonValue[] }) {
       ) : null}
       <ul
         className={`flex flex-col w-full ${
-          isInsideProps ? "pl-4" : "my-2 gap-2"
+          isInsideProps ? "pl-[2ch]" : "my-2 gap-2"
         }`}
       >
         {values.map((subValue, i) => {
@@ -309,7 +310,7 @@ function Props({ props }: { props: JsonObject }) {
   }
 
   return (
-    <div className="pl-6 flex flex-col">
+    <div className="pl-[3ch] flex flex-col">
       {rootProps
         .filter((rootProp) => rootProp !== "children")
         .map((rootProp, i) => {
@@ -380,7 +381,7 @@ function NodeComponent({ tag, props }: { tag: string; props: JsonObject }) {
         </summary>
 
         <PropsContext.Provider value={false}>
-          <div className="pl-4 flex flex-col gap-2 items-start">
+          <div className="pl-[2ch] flex flex-col gap-2 items-start">
             {tag.startsWith("$L") ? (
               <ComponentImportReference tag={tag} />
             ) : null}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+    font-variant-ligatures: none;
+}


### PR DESCRIPTION
Changes to TreeLine:
- Added JetBrains Mono (without ligatures because some people dislike them)
- Set font size to text-sm
- Use e.g. `p-[2ch]` instead of `pl-4` for consistent insets tied of the size of chars around them.


Before:
<img width="1311" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/7a46b8b7-8929-44f8-8290-9b0463d60774">

After:
<img width="1301" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/bb6c5ed2-9a33-49de-b6aa-6e97392e63cf">
