### PR TITLE
Rename some things to get closer to React

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Please make an issue on https://github.com/alvarlagerlof/rsc-parser/issues/new a
 
 Currently this is is a standalone site, which means that it is not able to handle live streaming payloads, but I plan on exploring using doing this as a browser extension or possibly an embedded debugging component similar to the [React Query devtools](https://tanstack.com/query/v4/docs/react/devtools). The latter would probably need a service worker to intercept network requests. If you know anything about this I'd love to talk. I'm [@alvarlagerlof](https://twitter.com/alvarlagerlof) on Twitter.
 
-~~I'm also considering a rendering of the component tree that looks more like your code itself. I think it should be possible to replicate it pretty well. In this area I am also considering attempting to combine the different lines in the stream and stitch them together into a single tree.~~ Done in #7
+~~I'm also considering a rendering of the component tree that looks more like your code itself. I think it should be possible to replicate it pretty well. In this area I am also considering attempting to combine the different rows in the stream and stitch them together into a single tree.~~ Done in #7
 
-Another area of improvement is better rendering of sizes of lines/objects. Browsers and servers have compression like gzip and brotli, but this codes does not take that into account.
+Another area of improvement is better rendering of sizes of rows/objects. Browsers and servers have compression like gzip and brotli, but this codes does not take that into account.
 
 I do want to note that all of this was put together quickly, so it likely needs a bit of refactoring to make more sense.
 

--- a/app/Lines/ClientReferenceRow.tsx
+++ b/app/Lines/ClientReferenceRow.tsx
@@ -11,7 +11,7 @@ const schema = z
   })
   .strict();
 
-export function ImportLine({ data }: { data: string }) {
+export function ClientReferenceRow({ data }: { data: string }) {
   const json = JSON.parse(data);
   const parsed = schema.parse(json);
 

--- a/app/Lines/HintRow.tsx
+++ b/app/Lines/HintRow.tsx
@@ -8,7 +8,7 @@ const schema = z.tuple([
   ]),
 ]);
 
-export function AssetLine({ data }: { data: string }) {
+export function HintRow({ data }: { data: string }) {
   const json = JSON.parse(data);
   const parsed = schema.parse(json);
 

--- a/app/Lines/TreeRow.spec.tsx
+++ b/app/Lines/TreeRow.spec.tsx
@@ -2,9 +2,9 @@ import { JsonValue } from "type-fest";
 import {
   refineRawTreeNode,
   TYPE_OTHER,
-  TYPE_COMPONENT,
+  TYPE_ELEMENT,
   TYPE_ARRAY,
-} from "./TreeLine";
+} from "./TreeRow";
 
 describe("getTreeNode", () => {
   it("handles a null", () => {
@@ -86,7 +86,7 @@ describe("getTreeNode", () => {
     ];
     const refined = refineRawTreeNode(rawValue);
 
-    expect(refined.type).toBe(TYPE_COMPONENT);
+    expect(refined.type).toBe(TYPE_ELEMENT);
     expect(refined.value).toStrictEqual(rawValue);
   });
 });

--- a/app/Parser.tsx
+++ b/app/Parser.tsx
@@ -329,6 +329,7 @@ function TabPanelExplorer({ row }: { row: string }) {
 
   switch (refinedType) {
     case "client ref":
+      // This is a bit iffy. Should probably have separate names for these.
       return <ClientReferenceRow data={data} />;
     case "hint":
       return <HintRow data={data} />;

--- a/app/parse.spec.ts
+++ b/app/parse.spec.ts
@@ -1,5 +1,5 @@
 import {
-  splitToCleanLines,
+  splitToCleanRows,
   lexer,
   UNKNOWN,
   COLON,
@@ -27,44 +27,44 @@ import {
  *
  */
 
-describe("splitToCleanLines", () => {
+describe("splitToCleanrows", () => {
   it("should fail if the input is not a string", () => {
-    const lines = null;
+    const rows = null;
 
     // @ts-expect-error Not a string
-    expect(() => splitToCleanLines(lines)).toThrow("Payload is not a string.");
+    expect(() => splitToCleanRows(rows)).toThrow("Payload is not a string.");
   });
 
   it("should return an empty array for an empty input", () => {
-    const lines = ``;
+    const rows = ``;
 
-    expect(splitToCleanLines(lines)).toStrictEqual([]);
+    expect(splitToCleanRows(rows)).toStrictEqual([]);
   });
 
-  it("should split into clean lines", () => {
-    const lines = `foo
+  it("should split into clean rows", () => {
+    const rows = `foo
 bar
 baz
 `;
 
-    expect(splitToCleanLines(lines)).toStrictEqual(["foo", "bar", "baz"]);
+    expect(splitToCleanRows(rows)).toStrictEqual(["foo", "bar", "baz"]);
   });
 
-  it("should not accept empty lines in between", () => {
-    const lines = `foo
+  it("should not accept empty rows in between", () => {
+    const rows = `foo
 bar
 baz
 `;
 
-    expect(splitToCleanLines(lines)).toStrictEqual(["foo", "bar", "baz"]);
+    expect(splitToCleanRows(rows)).toStrictEqual(["foo", "bar", "baz"]);
   });
 
-  it("should fail if the last line is not empty", () => {
-    const lines = `foo
+  it("should fail if the last row is not empty", () => {
+    const rows = `foo
 bar
 baz`;
 
-    expect(() => splitToCleanLines(lines)).toThrow(
+    expect(() => splitToCleanRows(rows)).toThrow(
       "RSC payload is missing an empty newline at the end indicating that it is not complete."
     );
   });
@@ -72,17 +72,17 @@ baz`;
 
 describe("lexer", () => {
   it("split nothing into an empty array", () => {
-    const line = ``;
+    const row = ``;
 
-    const result = lexer(line);
+    const result = lexer(row);
 
     expect(result).toStrictEqual([]);
   });
 
   it("split into array of objects", () => {
-    const line = `:{}[]01ab,`;
+    const row = `:{}[]01ab,`;
 
-    const result = lexer(line);
+    const result = lexer(row);
 
     expect(result).toStrictEqual([
       {
@@ -131,40 +131,40 @@ describe("lexer", () => {
 
 describe("parser", () => {
   it("should parse a number identifier", () => {
-    const line = `0:""`;
-    const tokens = lexer(line);
+    const row = `0:""`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({ identifier: "0", type: "", data: `""` });
   });
 
   it("should parse a letter identifier", () => {
-    const line = `a:""`;
-    const tokens = lexer(line);
+    const row = `a:""`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({ identifier: "a", type: "", data: `""` });
   });
 
   it("should parse a two-char identifier empty data string", () => {
-    const line = `0a:""`;
-    const tokens = lexer(line);
+    const row = `0a:""`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({ identifier: "0a", type: "", data: `""` });
   });
 
   it("should parse an empty data string", () => {
-    const line = `0:""`;
-    const tokens = lexer(line);
+    const row = `0:""`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({ identifier: "0", type: "", data: `""` });
   });
 
   it("should parse an non-empty data string", () => {
-    const line = `0:"$Sreact.suspense"`;
-    const tokens = lexer(line);
+    const row = `0:"$Sreact.suspense"`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({
@@ -175,8 +175,8 @@ describe("parser", () => {
   });
 
   it("should parse a data object", () => {
-    const line = `0:"{}"`;
-    const tokens = lexer(line);
+    const row = `0:"{}"`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({
@@ -187,8 +187,8 @@ describe("parser", () => {
   });
 
   it("should parse a data array", () => {
-    const line = `0:"[]"`;
-    const tokens = lexer(line);
+    const row = `0:"[]"`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({
@@ -199,8 +199,8 @@ describe("parser", () => {
   });
 
   it("should parse a data array an empty object inside of it", () => {
-    const line = `0:"[{}]"`;
-    const tokens = lexer(line);
+    const row = `0:"[{}]"`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({
@@ -211,8 +211,8 @@ describe("parser", () => {
   });
 
   it("should parse a data array multiple objects inside of it", () => {
-    const line = `0:"[{"a":"b"},{"foo":"bar"}]"`;
-    const tokens = lexer(line);
+    const row = `0:"[{"a":"b"},{"foo":"bar"}]"`;
+    const tokens = lexer(row);
     const result = parse(tokens);
 
     expect(result).toStrictEqual({

--- a/app/parse.ts
+++ b/app/parse.ts
@@ -1,19 +1,19 @@
-export function splitToCleanLines(payload: string) {
+export function splitToCleanRows(payload: string) {
   if (typeof payload !== "string") {
     throw new Error("Payload is not a string.");
   }
 
-  const lines = payload.split("\n");
+  const rows = payload.split("\n");
 
-  if (lines.at(-1) !== "") {
+  if (rows.at(-1) !== "") {
     throw new Error(
       "RSC payload is missing an empty newline at the end indicating that it is not complete."
     );
   }
 
-  lines.pop();
+  rows.pop();
 
-  return lines;
+  return rows;
 }
 
 export const COLON = "COLON" as const;
@@ -24,8 +24,8 @@ export const RIGHT_BRACE = "RIGHT_BRACE" as const;
 export const RIGHT_BRACKET = "RIGHT_BRACKET" as const;
 export const UNKNOWN = "UNKNOWN" as const;
 
-export function lexer(line: string) {
-  const chars = line.split("");
+export function lexer(row: string) {
+  const chars = row.split("");
 
   return chars.map((char) => {
     switch (char) {
@@ -122,16 +122,16 @@ export function parse(tokens: ReturnType<typeof lexer>) {
   };
 }
 
-export function refineLineType(rawType: string | undefined) {
+export function refineRowType(rawType: string | undefined) {
   switch (rawType) {
     case "": {
       return "tree";
     }
     case "I": {
-      return "import";
+      return "client ref";
     }
     case "HL": {
-      return "asset";
+      return "hint";
     }
     default: {
       return "unknown";


### PR DESCRIPTION
In an effort to make #22 simpler, and also to use naming that is closer to React (see [ReactFlightClient.js](https://github.com/facebook/react/blob/main/packages/react-client/src/ReactFlightClient.js)), I've renamed a bunch of stuff.

Changes:
```
line => row
lines => rows
TreeLine => TreeRow
ImportLine => ClientReferenceRow
AssetLine => HintRow
NodeComponent => NodeElement
TYPE_COMPONENT => TYPE_ELEMENT
reactComponentMarker => reactElementMarker
tag => elementType
```

I noticed a few typos along the way. Will make another PR for those.