### PR TITLE
Enable POST-ing payloads to show in the parser

### DIFF
--- a/app/payload/send/route.ts
+++ b/app/payload/send/route.ts
@@ -1,0 +1,31 @@
+export const runtime = "edge";
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+
+  const payload = formData.get("payload")?.toString();
+
+  if (payload) {
+    const templateLiteral = "`";
+
+    const modifiedPayload = Buffer.from(JSON.stringify(payload)).toString(
+      "base64"
+    );
+
+    const html = `
+        <script>
+            localStorage.setItem("payload", JSON.parse(window.atob(${templateLiteral}${modifiedPayload}${templateLiteral})));
+            window.location = "/";
+        </script>`;
+
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text / html",
+      },
+    });
+  }
+
+  return new Response("Invalid format", {
+    status: 403,
+  });
+}

--- a/app/payload/test/page.tsx
+++ b/app/payload/test/page.tsx
@@ -1,0 +1,13 @@
+export default function TestPayloadSend() {
+  return (
+    <form method="POST" action="/payload/send" className="p-20">
+      <textarea
+        name="payload"
+        placeholder="Enter payload"
+        className="w-full rounded bg-slate-100 p-3"
+        rows={15}
+      />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}


### PR DESCRIPTION
With this change, you an call /payload/send with a POST and FormData containing "payload" field.

Should solve for: https://twitter.com/matt_kruse/status/1664245298456059904

# How does it work?

Here's how the API can be used is in `app/payload/send`.

The way this works is a bit ugly, but I don't know of a better way. What happens is:
1. A route handler extracts the payload from the FormData
2. Converts it to JSON
3. Converts it to Base64

It then creates a HTML response that:
1. Converts from Base64 to JSON string
2. Converts JSON string to string (payload)
3. Save payload to localStorage
4. Redirects to "/"

Then parser will show the localStorage data.

This is maybe some kind of security nightmare, but the constraints that led me to this are:
- Next.js page can't read POST data.
- Headers are limited in size.
- Cookies are also therefor limited in size.

# Demo
Go to https://rsc-parser-git-send-payload-api-lagerlof.vercel.app/payload/test and enter an RSC payload.