### PR TITLE
Disable minification in core

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -27,5 +27,6 @@ export default defineConfig({
         },
       },
     },
+    minify: false,
   },
 });


### PR DESCRIPTION
Turned off minification for the vite build of `core`. Makes it easier to profile.