### PR TITLE
Use separate dist folder for core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,13 +38,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/core.js"
+      "import": "./dist/js/core.js"
     },
     "./style.css": {
       "import": "./dist/style.css"
     }
   },
-  "types": "./dist/src/main.d.ts",
+  "types": "./dist/js/src/main.d.ts",
   "style": "./dist/style.css",
   "dependencies": {
     "react-json-tree": "^0.18.0"

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -7,6 +7,7 @@ import dts from "vite-plugin-dts";
 export default defineConfig({
   plugins: [react(), dts()],
   build: {
+    outDir: "./dist/js",
     lib: {
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, "src/main.ts"),


### PR DESCRIPTION
When Tailwind and Vite were both running, Next.js would sometimes not find the css file.