### PR TITLE
Improve tree rendering

### DIFF
--- a/packages/core/src/rows/TreeRow.stories.tsx
+++ b/packages/core/src/rows/TreeRow.stories.tsx
@@ -115,6 +115,17 @@ export const ArrayProp: Story = {
   },
 };
 
+export const ArrayObjectProp: Story = {
+  args: {
+    data: JSON.stringify([
+      "$",
+      "div",
+      "0",
+      { x: { y: [{ foo: "bar" }, { foo: "bar" }] } },
+    ]),
+  },
+};
+
 export const ElementArray: Story = {
   args: {
     data: JSON.stringify([

--- a/packages/core/src/rows/TreeRow.stories.tsx
+++ b/packages/core/src/rows/TreeRow.stories.tsx
@@ -58,6 +58,12 @@ export const ElementWithChildren: Story = {
   },
 };
 
+export const ElementWithCodeChildren: Story = {
+  args: {
+    data: JSON.stringify(["$", "p", "0", { children: "{}" }]),
+  },
+};
+
 export const StringProp: Story = {
   args: {
     data: JSON.stringify(["$", "div", "0", { className: "test" }]),

--- a/packages/core/src/rows/TreeRow.stories.tsx
+++ b/packages/core/src/rows/TreeRow.stories.tsx
@@ -64,6 +64,12 @@ export const StringProp: Story = {
   },
 };
 
+export const EscapedStringProp: Story = {
+  args: {
+    data: JSON.stringify(["$", "div", "0", { className: 'this a "quote"' }]),
+  },
+};
+
 export const NumberProp: Story = {
   args: {
     data: JSON.stringify(["$", "Component", "0", { something: 0 }]),

--- a/packages/core/src/rows/TreeRow.stories.tsx
+++ b/packages/core/src/rows/TreeRow.stories.tsx
@@ -58,9 +58,15 @@ export const ElementWithChildren: Story = {
   },
 };
 
-export const ElementWithCodeChildren: Story = {
+export const ElementsWithCodeChildren: Story = {
   args: {
-    data: JSON.stringify(["$", "p", "0", { children: "{}" }]),
+    data: JSON.stringify([
+      ["$", "p", "0", { children: "{}" }],
+      ["$", "p", "0", { children: "()" }],
+      ["$", "p", "0", { children: "<>" }],
+      ["$", "p", "0", { children: "`" }],
+      ["$", "p", "0", { children: "``" }],
+    ]),
   },
 };
 

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -199,9 +199,7 @@ function NodeOther({ value }: { value: JsonValue }) {
     if (isInsideObject) {
       return <>undefined</>;
     }
-    return <JSContainer>undefined</JSContainer>;
-    // TODO: Potentially don't render {undefined}
-    // return null;
+    return null;
   }
 
   if (value === null) {
@@ -424,19 +422,40 @@ function NodeElement({ tag, props }: { tag: string; props: JsonObject }) {
     },
   });
 
+  const isInsideProps = useContext(PropsContext);
+
+  if (isInsideProps === undefined) {
+    throw new Error("PropsContext must be used within a PropsContext.Provider");
+  }
+
   const propsWithoutChildren = removeChildren(props);
   const hasVisibleProps =
     propsWithoutChildren !== undefined &&
     Object.keys(propsWithoutChildren).length > 0;
 
+  if (Object.keys(props).length === 0) {
+    return (
+      <span className={isInsideProps ? "" : "ml-[18px]"}>
+        <Purple>
+          <LeftArrow />
+        </Purple>
+        <Pink>{tag}</Pink>{" "}
+        <Purple>
+          /<RightArrow />
+        </Purple>
+      </span>
+    );
+  }
+
   return (
     <ObjectContext.Provider value={false}>
       <Ariakit.Disclosure
         store={disclosure}
-        className="-mx-2 -my-1 cursor-pointer ligatures-none rounded-lg p-1 outline outline-2 outline-transparent transition-all duration-200 hover:bg-slate-700/10 focus:bg-slate-700/10 dark:hover:bg-white/10 dark:focus:bg-white/10"
+        className="-mx-2 -my-1  ligatures-none rounded-lg p-1 outline outline-2 outline-transparent transition-all duration-200 focus:bg-slate-700/10 dark:focus:bg-white/10 cursor-pointer hover:bg-slate-700/10 dark:hover:bg-white/10"
         style={{ opacity: isPending ? 0.7 : 1 }}
       >
         {isOpen ? <DownArrowIcon /> : <RightArrowIcon />}
+
         <Purple>
           <LeftArrow />
         </Purple>
@@ -445,7 +464,14 @@ function NodeElement({ tag, props }: { tag: string; props: JsonObject }) {
           <>
             {hasVisibleProps ? null : (
               <Purple>
-                <RightArrow />
+                {props.children === undefined ? (
+                  <>
+                    {" "}
+                    /<RightArrow />
+                  </>
+                ) : (
+                  <RightArrow />
+                )}
               </Purple>
             )}
           </>
@@ -477,32 +503,44 @@ function NodeElement({ tag, props }: { tag: string; props: JsonObject }) {
             {hasVisibleProps ? (
               <>
                 <Props props={props} />
-                <div className="pl-[2ch]">
+                <div className="pl-[18px]">
                   <Purple>
-                    <RightArrow />
+                    {props.children === undefined ? (
+                      <>
+                        <Purple>
+                          /<RightArrow />
+                        </Purple>
+                      </>
+                    ) : (
+                      <RightArrow />
+                    )}
                   </Purple>
                 </div>
               </>
             ) : null}
 
-            <PropsContext.Provider value={false}>
-              <div className="flex flex-col items-start gap-2 py-1 pl-[calc(2ch+14px)]">
-                {tag.startsWith("$L") ? (
-                  <ClientReferenceAnnotation tag={tag} />
-                ) : null}
-                <Node value={props.children} />
-              </div>
-            </PropsContext.Provider>
+            {props.children === undefined ? null : (
+              <>
+                <PropsContext.Provider value={false}>
+                  <div className="flex flex-col items-start gap-2 py-1 pl-[calc(2ch+18px)]">
+                    {tag.startsWith("$L") ? (
+                      <ClientReferenceAnnotation tag={tag} />
+                    ) : null}
+                    <Node value={props.children} />
+                  </div>
+                </PropsContext.Provider>
 
-            <div className="pl-[14px]">
-              <Purple>
-                <LeftArrow />/
-              </Purple>
-              <Pink>{tag}</Pink>
-              <Purple>
-                <RightArrow />
-              </Purple>
-            </div>
+                <div className="pl-[18px]">
+                  <Purple>
+                    <LeftArrow />/
+                  </Purple>
+                  <Pink>{tag}</Pink>
+                  <Purple>
+                    <RightArrow />
+                  </Purple>
+                </div>
+              </>
+            )}
           </>
         ) : null}
       </Ariakit.DisclosureContent>

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -141,6 +141,10 @@ function JSContainer({ children }: { children: ReactNode }) {
 
 const ObjectContext = createContext(false);
 
+function isLetter(letter: string) {
+  return RegExp(/^\p{L}/, "u").test(letter);
+}
+
 function JSObjectValue({ value }: { value: JsonObject }) {
   const isInsideProps = useContext(PropsContext);
 
@@ -158,9 +162,14 @@ function JSObjectValue({ value }: { value: JsonObject }) {
 
       <div className="flex flex-col pl-[2ch]">
         {Object.entries(value).map(([entryKey, entryValue], i) => {
+          const needsDoubleQuotes = !isLetter(entryKey[0]);
           return (
             <span key={entryKey}>
-              <span>{entryKey}: </span>
+              <span>
+                {needsDoubleQuotes ? `"` : null}
+                {entryKey}
+                {needsDoubleQuotes ? `"` : null}:{" "}
+              </span>
               <Node value={entryValue} />
               {i !== Object.keys(value).length - 1 ? <>,</> : null}
             </span>
@@ -241,9 +250,17 @@ function StringValue({ value }: { value: string }) {
   }
 
   const needsSpecialHandling =
-    value.includes("\\") || value.includes("{") || value.includes("}");
+    value.includes("\\") ||
+    value.includes("{") ||
+    value.includes("}") ||
+    value.includes("<") ||
+    value.includes(">") ||
+    value.includes("(") ||
+    value.includes(")");
 
-  const formattedString = value.replaceAll(`"`, `&#92;"`);
+  const formattedString = value
+    .replaceAll(`"`, `&#92;"`)
+    .replaceAll(`\``, "\\`");
 
   if (!isInsideProps) {
     return (
@@ -254,12 +271,12 @@ function StringValue({ value }: { value: string }) {
               <LeftCurlyBrace />
             </Blue>
             <Yellow>
-              "
+              `
               <span
                 className="dark:text-white"
                 dangerouslySetInnerHTML={{ __html: formattedString }}
               />
-              "
+              `
             </Yellow>
             <Blue>
               <RightCurlyBrace />

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -240,10 +240,38 @@ function StringValue({ value }: { value: string }) {
     throw new Error("PropsContext must be used within a PropsContext.Provider");
   }
 
+  const needsSpecialHandling =
+    value.includes("\\") || value.includes("{") || value.includes("}");
+
+  const formattedString = value.replaceAll(`"`, `&#92;"`);
+
   if (!isInsideProps) {
     return (
       <div className="inline flex-col gap-2">
-        <span className="dark:text-white">{value}</span>
+        {needsSpecialHandling ? (
+          <>
+            <Blue>
+              <LeftCurlyBrace />
+            </Blue>
+            <Yellow>
+              "
+              <span
+                className="dark:text-white"
+                dangerouslySetInnerHTML={{ __html: formattedString }}
+              />
+              "
+            </Yellow>
+            <Blue>
+              <RightCurlyBrace />
+            </Blue>
+          </>
+        ) : (
+          <span
+            className="dark:text-white"
+            dangerouslySetInnerHTML={{ __html: formattedString }}
+          />
+        )}
+
         {value.startsWith("$L") ? (
           <TreeReferenceAnnotation reference={value} />
         ) : null}
@@ -255,9 +283,7 @@ function StringValue({ value }: { value: string }) {
     <div className="inline flex-col gap-2">
       <Yellow>
         &quot;
-        <span
-          dangerouslySetInnerHTML={{ __html: value.replaceAll(`"`, `&#92;"`) }}
-        />
+        <span dangerouslySetInnerHTML={{ __html: formattedString }} />
         &quot;
       </Yellow>
       {value.startsWith("$L") ? (

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -255,7 +255,13 @@ function StringValue({ value }: { value: string }) {
 
   return (
     <div className="inline flex-col gap-2">
-      <Yellow>&quot;{value}&quot;</Yellow>
+      <Yellow>
+        &quot;
+        <span
+          dangerouslySetInnerHTML={{ __html: value.replaceAll(`"`, `&#92;"`) }}
+        />
+        &quot;
+      </Yellow>
       {value.startsWith("$L") ? (
         <TreeReferenceAnnotation reference={value} />
       ) : null}

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -256,7 +256,8 @@ function StringValue({ value }: { value: string }) {
     value.includes("<") ||
     value.includes(">") ||
     value.includes("(") ||
-    value.includes(")");
+    value.includes(")") ||
+    value.includes("`");
 
   const formattedString = value
     .replaceAll(`"`, `&#92;"`)

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -292,7 +292,7 @@ function NodeArray({ values }: { values: JsonValue[] | readonly JsonValue[] }) {
       ) : null}
       <ul
         className={`flex w-full flex-col ${
-          isInsideProps ? "pl-[4ch]" : "my-2 gap-2"
+          isInsideProps ? "pl-[4ch]" : "gap-1"
         }`}
       >
         {values.map((subValue, i) => {
@@ -451,7 +451,7 @@ function NodeElement({ tag, props }: { tag: string; props: JsonObject }) {
     <ObjectContext.Provider value={false}>
       <Ariakit.Disclosure
         store={disclosure}
-        className="-mx-2 -my-1  ligatures-none rounded-lg p-1 outline outline-2 outline-transparent transition-all duration-200 focus:bg-slate-700/10 dark:focus:bg-white/10 cursor-pointer hover:bg-slate-700/10 dark:hover:bg-white/10"
+        className="ligatures-none rounded-lg py-0.5 -my-0.5 outline outline-2 outline-transparent transition-all duration-200 focus:bg-slate-700/10 dark:focus:bg-white/10 cursor-pointer hover:bg-slate-700/10 dark:hover:bg-white/10"
         style={{ opacity: isPending ? 0.7 : 1 }}
       >
         {isOpen ? <DownArrowIcon /> : <RightArrowIcon />}
@@ -522,7 +522,7 @@ function NodeElement({ tag, props }: { tag: string; props: JsonObject }) {
             {props.children === undefined ? null : (
               <>
                 <PropsContext.Provider value={false}>
-                  <div className="flex flex-col items-start gap-2 py-1 pl-[calc(2ch+18px)]">
+                  <div className="flex flex-col items-start gap-2 pl-[calc(2ch+18px)]">
                     {tag.startsWith("$L") ? (
                       <ClientReferenceAnnotation tag={tag} />
                     ) : null}

--- a/packages/core/tailwind.config.js
+++ b/packages/core/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require("tailwindcss/plugin");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.tsx"],
@@ -16,5 +18,13 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        ".ligatures-none": {
+          fontVariantLigatures: "none",
+        },
+      });
+    }),
+  ],
 };


### PR DESCRIPTION
- Tweaked styles for nesting inset levels
- Improved JSX correctness (can now often copy the tree text directly into an editor and have it be recognized as valid JSX)
- Disabled ligatures in ending tags (the colors where mixing incorrectly)
- Added `user-select: none;` to tree and client reference info boxes (helps copy paste into an editor).