### PR TITLE
Refactor fetch patch

### DIFF
--- a/packages/chrome-extension/public/fetch-patch.js
+++ b/packages/chrome-extension/public/fetch-patch.js
@@ -59,7 +59,7 @@ window.fetch = async (...args) => {
           chunkEndTime,
         },
       },
-      "*"
+      "*",
     );
   }
 

--- a/packages/chrome-extension/public/fetch-patch.js
+++ b/packages/chrome-extension/public/fetch-patch.js
@@ -1,12 +1,31 @@
-const { fetch: originalFetch } = window;
+if (typeof window.originalFetch === "undefined") {
+  window.originalFetch = window.fetch;
+}
 
 window.fetch = async (...args) => {
   const fetchStartTime = Date.now();
 
-  let [url, config] = args;
-  const response = await originalFetch(url, config);
+  let url = undefined;
+  let headers = undefined;
+  if (args[0] instanceof Request) {
+    url = args[0].url;
+    headers = args[0].headers;
+  } else if (typeof args[0] === "string" || args[0] instanceof URL) {
+    url = args[0].toString();
+    headers = args[1].headers;
+  }
 
-  if (config.headers["RSC"] !== "1") {
+  const response = await window.originalFetch(...args);
+
+  if (typeof headers === "undefined" || typeof headers === "undefined") {
+    return response;
+  }
+
+  if (headers instanceof Headers && !headers.has("RSC")) {
+    return response;
+  }
+
+  if (headers instanceof Object && typeof headers["RSC"] === "undefined") {
     return response;
   }
 
@@ -29,18 +48,18 @@ window.fetch = async (...args) => {
       {
         type: "RSC_CHUNK",
         data: {
-          fetchUrl: url.toString(),
+          fetchUrl: url,
           fetchHeaders:
-            config.headers instanceof Headers
-              ? Object.fromEntries(config.headers.entries())
-              : config.headers,
+            headers instanceof Headers
+              ? Object.fromEntries(headers.entries())
+              : headers,
           fetchStartTime,
           chunkValue: value,
           chunkStartTime,
           chunkEndTime,
         },
       },
-      "*",
+      "*"
     );
   }
 


### PR DESCRIPTION
The previous fetch patch was not exhaustive enough. For example, it did not handle `fetch(new Request(...))` properly, causing sites like YouTube to fail.

I've rewritten some of the code to be able to handle this now, and also to abort to returning the response unmodified in case enough data to run the custom stuff is not available, meaning it should break less often.

There's also now handling of plain `header` objects vs `new Header()`.

I also changed the code that copies `fetch` to `originalFetch` to make it possible to execute the script multiple times without overwriting the original `fetch` (`originalFetch`) each time.

Fixes #143