### PR TITLE
Better time scrubber timeline

### DIFF
--- a/packages/chrome-extension/src/App.tsx
+++ b/packages/chrome-extension/src/App.tsx
@@ -13,7 +13,7 @@ export function App() {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       _sender: unknown,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      _sendResponse: unknown,
+      _sendResponse: unknown
     ) {
       if (isRscChunkMessage(request)) {
         // if (request.data.fetchUrl !== tab.getState().activeId) {
@@ -31,14 +31,14 @@ export function App() {
     (accumulator, current) => {
       if (
         !accumulator.find(
-          (item) => item.data.chunkValue === current.data.chunkValue,
+          (item) => item.data.chunkValue === current.data.chunkValue
         )
       ) {
         accumulator.push(current);
       }
       return accumulator;
     },
-    [] as RscChunkMessage[],
+    [] as RscChunkMessage[]
   );
 
   const sortedMessages = deduplicatedMessages.sort((a, b) => {
@@ -46,7 +46,7 @@ export function App() {
   });
 
   const filteredMessages = sortedMessages.filter(
-    (message) => !message.data.chunkValue.includes("DOCTYPE"),
+    (message) => !message.data.chunkValue.includes("DOCTYPE")
   );
 
   return (

--- a/packages/chrome-extension/src/App.tsx
+++ b/packages/chrome-extension/src/App.tsx
@@ -13,7 +13,7 @@ export function App() {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       _sender: unknown,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      _sendResponse: unknown
+      _sendResponse: unknown,
     ) {
       if (isRscChunkMessage(request)) {
         // if (request.data.fetchUrl !== tab.getState().activeId) {
@@ -31,14 +31,14 @@ export function App() {
     (accumulator, current) => {
       if (
         !accumulator.find(
-          (item) => item.data.chunkValue === current.data.chunkValue
+          (item) => item.data.chunkValue === current.data.chunkValue,
         )
       ) {
         accumulator.push(current);
       }
       return accumulator;
     },
-    [] as RscChunkMessage[]
+    [] as RscChunkMessage[],
   );
 
   const sortedMessages = deduplicatedMessages.sort((a, b) => {
@@ -46,7 +46,7 @@ export function App() {
   });
 
   const filteredMessages = sortedMessages.filter(
-    (message) => !message.data.chunkValue.includes("DOCTYPE")
+    (message) => !message.data.chunkValue.includes("DOCTYPE"),
   );
 
   return (

--- a/packages/core/src/stream/TimeScrubber.tsx
+++ b/packages/core/src/stream/TimeScrubber.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { RscChunkMessage } from "./message";
 import { useFilterMessagesByEndTime, useTimeRange } from "./hooks";
 
 export function useTimeScrubber(
   messages: RscChunkMessage[],
-  { follow }: { follow: boolean },
+  { follow }: { follow: boolean }
 ) {
   const { minStartTime, maxEndTime } = useTimeRange(messages);
   const [endTime, setEndTime] = useState(maxEndTime);
@@ -39,6 +39,57 @@ export function useTimeScrubber(
   };
 }
 
+function random(seed: number) {
+  const x = Math.sin(seed++) * 10000;
+  return x - Math.floor(x);
+}
+
+function useTracks(messages: RscChunkMessage[]) {
+  return useMemo(() => {
+    const messageTracks: Array<Array<RscChunkMessage>> = [[]];
+
+    for (const message of messages) {
+      // Find a track that doesn't overlap with the current message
+      const track = messageTracks.find((track) => {
+        const lastMessage = track[track.length - 1];
+
+        if (!lastMessage) {
+          return true;
+        }
+
+        if (lastMessage.data.fetchStartTime === message.data.fetchStartTime) {
+          return true;
+        }
+
+        const lastMessageWithSameFetchUrl = messages
+          .filter(
+            (m) => m.data.fetchStartTime === lastMessage.data.fetchStartTime
+          )
+          .at(-1);
+
+        if (
+          lastMessage.data.fetchStartTime !== message.data.fetchStartTime &&
+          typeof lastMessageWithSameFetchUrl !== "undefined" &&
+          lastMessageWithSameFetchUrl.data.chunkEndTime <
+            message.data.fetchStartTime
+        ) {
+          return true;
+        }
+
+        return false;
+      });
+
+      if (track) {
+        track.push(message);
+      } else {
+        messageTracks.push([message]);
+      }
+    }
+
+    return messageTracks;
+  }, [messages]);
+}
+
 export function TimeScrubber({
   messages,
   endTime,
@@ -48,67 +99,107 @@ export function TimeScrubber({
   minStartTime,
   maxEndTime,
 }: ReturnType<typeof useTimeScrubber>) {
-  const messageTimePercentages = messages.map((message) => {
-    const percentage =
-      ((message.data.chunkStartTime - minStartTime) /
-        (maxEndTime - minStartTime)) *
-      100;
-
-    return percentage;
-  });
-
   const filteredMessages = useFilterMessagesByEndTime(messages, endTime);
+  const tracks = useTracks(messages);
+
+  const messageHeight = 12;
+  const trackSpacing = 4;
+  const trackPadding = 8;
 
   return (
-    <div className="flex w-full flex-col gap-2 rounded-lg bg-slate-200  px-2 py-1 dark:bg-slate-700 dark:text-white">
-      <div className="flex flex-row gap-2">
-        <div className="tabular-nums text-slate-700 dark:text-slate-300">
-          {new Date(visibleEndTime).toLocaleTimeString()} /{" "}
-          {new Date(maxEndTime).toLocaleTimeString()}
-        </div>
+    <div className="flex w-full flex-col gap-2 rounded-xl bg-slate-200 p-2 dark:bg-slate-700 dark:text-white">
+      <div className="relative flex flex-row items-center transition-opacity delay-[50] duration-100">
         <input
           type="range"
-          className="grow"
+          className={[
+            "absolute h-full w-full rounded-md z-20",
+            "appearance-none",
+            "bg-transparent bg-gradient-to-r from-blue-100/25 to-blue-100/25 bg-no-repeat",
+            "[&::-webkit-slider-runnable-track]:bg-transparent",
+            "[&::-webkit-slider-runnable-track]:h-full",
+            "[&::-webkit-slider-thumb]:h-[calc(100%-6px)]",
+            "[&::-webkit-slider-thumb]:mt-[calc(6px/2)]",
+            "[&::-webkit-slider-thumb]:w-1",
+            "[&::-webkit-slider-thumb]:appearance-none",
+            "[&::-webkit-slider-thumb]:rounded",
+            "[&::-webkit-slider-thumb]:transition-colors",
+            "[&::-webkit-slider-thumb]:delay-[50]",
+            "[&::-webkit-slider-thumb]:duration-100",
+            isPending
+              ? "[&::-webkit-slider-thumb]:bg-blue-300"
+              : "[&::-webkit-slider-thumb]:bg-blue-500",
+            "[&::-webkit-slider-thumb]:z-20",
+          ].join(" ")}
           min={minStartTime}
           max={maxEndTime}
           value={visibleEndTime}
+          style={{
+            backgroundSize:
+              ((visibleEndTime - minStartTime) * 100) /
+                (maxEndTime - minStartTime) +
+              "% 100%",
+          }}
           onChange={(event) => {
             const numberValue = Number.parseFloat(event.target.value);
             changeEndTime(numberValue);
           }}
         ></input>
-      </div>
 
-      <div
-        className={`flex flex-row gap-2 transition-opacity delay-[50] duration-100 ${
-          isPending ? "opacity-60" : ""
-        }`}
-      >
-        <div className="whitespace-nowrap tabular-nums text-slate-700 dark:text-slate-300">
-          {String(filteredMessages.length).padStart(
-            String(messages.length).length,
-            "0",
-          )}{" "}
-          / {messages.length}
-        </div>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           version="1.1"
           width="100%"
-          height="20px"
-          className="stroke-slate-400 dark:stroke-slate-300"
+          height={`${
+            tracks.length *
+              (messageHeight + (tracks.length > 1 ? trackSpacing : 0)) +
+            trackPadding * 2
+          }px`}
+          className="pointer-events-none z-10 rounded-md bg-white fill-slate-500"
         >
-          <circle cx="100px" cy="100px" r="1px" stroke="black" />
-          {messageTimePercentages.map((percentage, idx) => (
-            <line
-              key={`circle-${idx}`}
-              x1={`${percentage}%`}
-              y1="0px"
-              x2={`${percentage}%`}
-              y2="100%"
-            />
-          ))}
+          {tracks.map((track, idx) => {
+            return track.map((message) => {
+              const x =
+                ((message.data.chunkStartTime - minStartTime) /
+                  (maxEndTime - minStartTime)) *
+                100;
+
+              const y = idx * (messageHeight + trackSpacing) + trackPadding;
+
+              const width =
+                ((message.data.chunkEndTime - message.data.chunkStartTime) /
+                  (maxEndTime - minStartTime)) *
+                100;
+
+              return (
+                <rect
+                  x={`${x * 0.98 + 1}%`}
+                  y={`${y}px`}
+                  width={width > 0.2 ? `${width}%` : "0.2%"}
+                  height={messageHeight}
+                  fill={`oklch(80% 0.15 ${
+                    random(message.data.fetchStartTime) * 360
+                  })`}
+                  rx="1"
+                />
+              );
+            });
+          })}
         </svg>
+      </div>
+
+      <div className="flex flex-row justify-between">
+        <div className="tabular-nums text-slate-700 dark:text-slate-300">
+          {new Date(visibleEndTime).toLocaleTimeString()} /{" "}
+          {new Date(maxEndTime).toLocaleTimeString()}
+        </div>
+
+        <div className="whitespace-nowrap tabular-nums text-slate-700 dark:text-slate-300">
+          {String(filteredMessages.length).padStart(
+            String(messages.length).length,
+            "0"
+          )}{" "}
+          / {messages.length}
+        </div>
       </div>
     </div>
   );

--- a/packages/core/src/stream/TimeScrubber.tsx
+++ b/packages/core/src/stream/TimeScrubber.tsx
@@ -4,7 +4,7 @@ import { useFilterMessagesByEndTime, useTimeRange } from "./hooks";
 
 export function useTimeScrubber(
   messages: RscChunkMessage[],
-  { follow }: { follow: boolean }
+  { follow }: { follow: boolean },
 ) {
   const { minStartTime, maxEndTime } = useTimeRange(messages);
   const [endTime, setEndTime] = useState(maxEndTime);
@@ -63,7 +63,7 @@ function useTracks(messages: RscChunkMessage[]) {
 
         const lastMessageWithSameFetchUrl = messages
           .filter(
-            (m) => m.data.fetchStartTime === lastMessage.data.fetchStartTime
+            (m) => m.data.fetchStartTime === lastMessage.data.fetchStartTime,
           )
           .at(-1);
 
@@ -196,7 +196,7 @@ export function TimeScrubber({
         <div className="whitespace-nowrap tabular-nums text-slate-700 dark:text-slate-300">
           {String(filteredMessages.length).padStart(
             String(messages.length).length,
-            "0"
+            "0",
           )}{" "}
           / {messages.length}
         </div>


### PR DESCRIPTION
Made some improvements to the time scrubber timeline:
- Overlayed the range input on top of the timeline.
- Custom styles for the range input.
- Created tracks where each message will be grouped by the fetch, and not overlap other messages.

<img width="826" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/30081e12-3106-403a-a181-21b9edefb583">
