### PR TITLE
Add `overflow-y: scroll;` to index.html

### DIFF
--- a/packages/chrome-extension/index.html
+++ b/packages/chrome-extension/index.html
@@ -17,6 +17,7 @@
       min-height: 100%;
       min-width: 100%;
       display: flex;
+      overflow-y: scroll;
     "
   >
     <div id="root" style="width: 100%"></div>


### PR DESCRIPTION
This avoids layout shift when the extension content grows.