### PR TITLE
Optimize raw data viewer

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,6 @@
   "types": "./dist/js/src/main.d.ts",
   "style": "./dist/style.css",
   "dependencies": {
-    "react-error-boundary": "^4.0.10",
-    "react-json-tree": "^0.18.0"
+    "react-error-boundary": "^4.0.10"
   }
 }

--- a/packages/core/src/icons.tsx
+++ b/packages/core/src/icons.tsx
@@ -1,0 +1,27 @@
+export function DownArrowIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={18}
+      className="inline text-slate-900 dark:text-slate-100"
+    >
+      <title>Down arrow</title>
+      <path d="M12 16L6 10H18L12 16Z" fill="currentColor"></path>
+    </svg>
+  );
+}
+
+export function RightArrowIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={18}
+      className="inline text-slate-900 dark:text-slate-100"
+    >
+      <title>Right arrow</title>
+      <path d="M16 12L10 18V6L16 12Z" fill="currentColor"></path>
+    </svg>
+  );
+}

--- a/packages/core/src/rows/TreeRow.tsx
+++ b/packages/core/src/rows/TreeRow.tsx
@@ -17,6 +17,7 @@ import {
   TYPE_OTHER,
   refineRawTreeNode,
 } from "./refineRawTreeNode.js";
+import { DownArrowIcon, RightArrowIcon } from "../icons.jsx";
 
 export const ClickClientReferenceContext = createContext<{
   onClickClientReference: (name: string) => void;
@@ -398,34 +399,6 @@ function removeChildren(props: Record<string, unknown>) {
       result[current] = props[current];
       return result;
     }, {});
-}
-
-function DownArrowIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      width={18}
-      className="inline text-slate-900 dark:text-slate-100"
-    >
-      <title>Down arrow</title>
-      <path d="M12 16L6 10H18L12 16Z" fill="currentColor"></path>
-    </svg>
-  );
-}
-
-function RightArrowIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      width={18}
-      className="inline text-slate-900 dark:text-slate-100"
-    >
-      <title>Right arrow</title>
-      <path d="M16 12L10 18V6L16 12Z" fill="currentColor"></path>
-    </svg>
-  );
 }
 
 function NodeElement({ tag, props }: { tag: string; props: JsonObject }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,7 +2579,6 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-error-boundary: ^4.0.10
-    react-json-tree: ^0.18.0
     storybook: ^7.1.1
     storybook-dark-mode: ^3.0.0
     tailwindcss: ^3.3.3


### PR DESCRIPTION
Below the trees, there's been two dropdowns to view raw JSON data as a string or using `react-json-tree`.

It turns out these are quite slow to render. To improve this, I've removed `react-json-tree` (it was not that useful) and made the string render properly format the json. I also made it so that none of this runs until you expand the tag.

<img width="1304" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/2d605f09-e4f4-44e5-8da1-a24240c4718f">
