### PR TITLE
Move Parser component to core as PayloadViewer

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -6,6 +6,7 @@ import { RowTabs } from "./tabs/row/RowTabs";
 import { parse, refineRowType, lexer, splitToCleanRows } from "./parse";
 import { StreamTabs } from "./stream/StreamTabs";
 import { RawStream } from "./stream/RawStream";
+import { PayloadViewer } from "./viewer/PayloadViewer";
 import { RscChunkMessage } from "./stream/message";
 
 export {
@@ -19,6 +20,7 @@ export {
   splitToCleanRows,
   RowTabs,
   StreamTabs,
+  PayloadViewer,
   RawStream,
   type RscChunkMessage,
 };

--- a/packages/core/src/viewer/PayloadViewer.stories.tsx
+++ b/packages/core/src/viewer/PayloadViewer.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PayloadViewer } from "./PayloadViewer";
+import { nextJsExampleData } from "../example-data/nextjs";
+import { ghNextExampleData } from "../example-data/gh-next";
+import { neurodiversityWikiExampleData } from "../example-data/neurodiversity-wiki";
+import { RscChunkMessage } from "../main";
+
+const meta: Meta<typeof PayloadViewer> = {
+  component: PayloadViewer,
+};
+
+export default meta;
+type Story = StoryObj<typeof PayloadViewer>;
+
+function getUrls(messages: RscChunkMessage[]) {
+  return Array.from(new Set(messages.map((message) => message.data.fetchUrl)));
+}
+
+function getPayloadByUrl(messages: RscChunkMessage[], url: string) {
+  return messages
+    .filter((message) => message.data.fetchUrl === url)
+    .map((message) => message.data.chunkValue)
+    .join("");
+}
+
+export const NextJs: Story = {
+  name: "nextjs.org",
+  argTypes: {
+    defaultPayload: {
+      options: getUrls(nextJsExampleData),
+      mapping: getUrls(nextJsExampleData).reduce(
+        (acc, url) => {
+          acc[url] = getPayloadByUrl(nextJsExampleData, url);
+          return acc;
+        },
+        {} as Record<string, string>
+      ),
+      control: {
+        type: "select",
+      },
+    },
+  },
+  args: {
+    defaultPayload: getPayloadByUrl(
+      nextJsExampleData,
+      getUrls(nextJsExampleData)[0]
+    ),
+  },
+  render: ({ defaultPayload }) => (
+    <PayloadViewer defaultPayload={defaultPayload} key={defaultPayload} />
+  ),
+};
+
+export const GhNext: Story = {
+  name: "gh-issues.vercel.app",
+  argTypes: {
+    defaultPayload: {
+      options: getUrls(ghNextExampleData),
+      mapping: getUrls(ghNextExampleData).reduce(
+        (acc, url) => {
+          acc[url] = getPayloadByUrl(ghNextExampleData, url);
+          return acc;
+        },
+        {} as Record<string, string>
+      ),
+      control: {
+        type: "select",
+      },
+    },
+  },
+  args: {
+    defaultPayload: getPayloadByUrl(
+      ghNextExampleData,
+      getUrls(ghNextExampleData)[0]
+    ),
+  },
+  render: ({ defaultPayload }) => (
+    <PayloadViewer defaultPayload={defaultPayload} key={defaultPayload} />
+  ),
+};
+
+export const NeurodiversityWiki: Story = {
+  name: "neurodiversity.wiki",
+  argTypes: {
+    defaultPayload: {
+      options: getUrls(neurodiversityWikiExampleData),
+      mapping: getUrls(neurodiversityWikiExampleData).reduce(
+        (acc, url) => {
+          acc[url] = getPayloadByUrl(neurodiversityWikiExampleData, url);
+          return acc;
+        },
+        {} as Record<string, string>
+      ),
+      control: {
+        type: "select",
+      },
+    },
+  },
+  args: {
+    defaultPayload: getPayloadByUrl(
+      neurodiversityWikiExampleData,
+      getUrls(neurodiversityWikiExampleData)[0]
+    ),
+  },
+  render: ({ defaultPayload }) => (
+    <PayloadViewer defaultPayload={defaultPayload} key={defaultPayload} />
+  ),
+};

--- a/packages/core/src/viewer/PayloadViewer.stories.tsx
+++ b/packages/core/src/viewer/PayloadViewer.stories.tsx
@@ -34,7 +34,7 @@ export const NextJs: Story = {
           acc[url] = getPayloadByUrl(nextJsExampleData, url);
           return acc;
         },
-        {} as Record<string, string>
+        {} as Record<string, string>,
       ),
       control: {
         type: "select",
@@ -44,7 +44,7 @@ export const NextJs: Story = {
   args: {
     defaultPayload: getPayloadByUrl(
       nextJsExampleData,
-      getUrls(nextJsExampleData)[0]
+      getUrls(nextJsExampleData)[0],
     ),
   },
   render: ({ defaultPayload }) => (
@@ -62,7 +62,7 @@ export const GhNext: Story = {
           acc[url] = getPayloadByUrl(ghNextExampleData, url);
           return acc;
         },
-        {} as Record<string, string>
+        {} as Record<string, string>,
       ),
       control: {
         type: "select",
@@ -72,7 +72,7 @@ export const GhNext: Story = {
   args: {
     defaultPayload: getPayloadByUrl(
       ghNextExampleData,
-      getUrls(ghNextExampleData)[0]
+      getUrls(ghNextExampleData)[0],
     ),
   },
   render: ({ defaultPayload }) => (
@@ -90,7 +90,7 @@ export const NeurodiversityWiki: Story = {
           acc[url] = getPayloadByUrl(neurodiversityWikiExampleData, url);
           return acc;
         },
-        {} as Record<string, string>
+        {} as Record<string, string>,
       ),
       control: {
         type: "select",
@@ -100,7 +100,7 @@ export const NeurodiversityWiki: Story = {
   args: {
     defaultPayload: getPayloadByUrl(
       neurodiversityWikiExampleData,
-      getUrls(neurodiversityWikiExampleData)[0]
+      getUrls(neurodiversityWikiExampleData)[0],
     ),
   },
   render: ({ defaultPayload }) => (

--- a/packages/core/src/viewer/PayloadViewer.tsx
+++ b/packages/core/src/viewer/PayloadViewer.tsx
@@ -1,0 +1,44 @@
+import React, { ChangeEvent, useEffect, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { RowTabs } from "../tabs/row/RowTabs";
+import { GenericErrorBoundaryFallback } from "../GenericErrorBoundaryFallback";
+
+export function PayloadViewer({ defaultPayload }: { defaultPayload: string }) {
+  const [payload, setPayload] = useState(defaultPayload);
+
+  useEffect(() => {
+    const previous = localStorage.getItem("payload");
+    setPayload(previous ?? defaultPayload);
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <form className="flex w-full flex-col gap-2">
+        <label htmlFor="payload" className="font-medium">
+          Payload
+        </label>
+
+        <textarea
+          name="payload"
+          placeholder="RCS payload"
+          className="resize-none rounded-md bg-slate-200 p-3 dark:bg-slate-800 dark:text-slate-200"
+          rows={16}
+          value={payload}
+          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+            setPayload(event.target.value);
+            localStorage.setItem("payload", event.target.value);
+          }}
+          spellCheck="false"
+        />
+      </form>
+      <div className="w-full">
+        <ErrorBoundary
+          FallbackComponent={GenericErrorBoundaryFallback}
+          key={payload}
+        >
+          <RowTabs payload={payload} />
+        </ErrorBoundary>
+      </div>
+    </div>
+  );
+}

--- a/packages/website/app/PayloadViewerClientWrapper.tsx
+++ b/packages/website/app/PayloadViewerClientWrapper.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import React, { ChangeEvent, useEffect, useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { RowTabs } from "@rsc-parser/core";
-import { GenericErrorBoundaryFallback } from "./GenericErrorBoundaryFallback";
+import React from "react";
+import { PayloadViewer } from "@rsc-parser/core";
 
 import "@rsc-parser/core/style.css";
 
@@ -21,44 +19,6 @@ b:I{"id":"25548","chunks":["414:static/chunks/414-9ee1a4f70730f5c0.js","1004:sta
 9:[["$","$Lb","9b1d7e4d-d418-46ff-a539-9fab5bc4ab7b",{"post":{"_id":"9b1d7e4d-d418-46ff-a539-9fab5bc4ab7b","slug":{"current":"skeleton-loading-with-suspense-in-next-js-13","_type":"slug"},"title":"Skeleton Loading with Suspense in Next.js 13","description":"My strategy for handling skeleton loading with Suspense.","date":{"published":"2022-12-29","updated":"2022-12-29"}}}],["$","$Lb","7cdcfec7-d8c4-40f7-9b71-cc323c2e8136",{"post":{"title":"TailwindCSS with @next/font","description":"Here's how to integrate the new @next/font in Next.js 13 with TailwindCSS.","date":{"published":"2022-10-30","updated":"2022-10-30"},"_id":"7cdcfec7-d8c4-40f7-9b71-cc323c2e8136","slug":{"current":"tailwindcss-with-next-font","_type":"slug"}}}],["$","$Lb","eb686ea0-cdd4-48eb-89d0-0876e5a39e01",{"post":{"_id":"eb686ea0-cdd4-48eb-89d0-0876e5a39e01","slug":{"current":"thoughts-on-photography-tools","_type":"slug"},"title":"Thoughts on Photography Tools","description":"The tool I'm looking for doesn't seem to exist","date":{"published":"2022-07-15","updated":null}}}],["$","$Lb","a32c3dcf-6a61-42dd-ab7a-c36fa21016ac",{"post":{"_id":"a32c3dcf-6a61-42dd-ab7a-c36fa21016ac","slug":{"_type":"slug","current":"always-add-name-to-type-radio"},"title":"Always add \\"name to type=\\"radio\\"","description":"Otherwise, you'll think your tab keys hate you","date":{"published":"2022-04-06","updated":null}}}]]
 `;
 
-export function Parser() {
-  const [payload, setPayload] = useState(defaultPayload);
-
-  useEffect(() => {
-    const previous = localStorage.getItem("payload");
-    setPayload(previous ?? defaultPayload);
-  }, []);
-
-  return (
-    <div className="flex max-w-full flex-col items-center gap-2">
-      <form className="flex w-full max-w-5xl flex-col gap-2 px-4">
-        <label htmlFor="paylod" className="font-medium">
-          Payload
-        </label>
-
-        <textarea
-          name="payload"
-          placeholder="RCS paylod"
-          className="resize-none rounded-lg bg-slate-300 p-3 outline outline-2 outline-offset-2 outline-transparent transition-all duration-200 focus:outline-blue-400 dark:bg-slate-800 dark:text-slate-200"
-          rows={16}
-          value={payload}
-          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
-            setPayload(event.target.value);
-            localStorage.setItem("payload", event.target.value);
-          }}
-          spellCheck="false"
-        />
-      </form>
-      <div className="min-h-[calc(100vh-120px)] w-full max-w-full">
-        <ErrorBoundary
-          FallbackComponent={GenericErrorBoundaryFallback}
-          key={payload}
-        >
-          <div className="flex w-full flex-col items-center justify-center gap-2 px-2 py-6 md:max-w-7xl">
-            <RowTabs payload={payload} />
-          </div>
-        </ErrorBoundary>
-      </div>
-    </div>
-  );
+export function PayloadViewerClientWrapper() {
+  return <PayloadViewer defaultPayload={defaultPayload} />;
 }

--- a/packages/website/app/layout.tsx
+++ b/packages/website/app/layout.tsx
@@ -21,7 +21,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark:bg-slate-950 dark:text-white">
+    <html
+      lang="en"
+      className="overflow-y-scroll bg-slate-50 dark:bg-slate-950 dark:text-white"
+    >
       <body className={[inter.className, jetBrainsMono.variable].join(" ")}>
         {children}
       </body>

--- a/packages/website/app/page.tsx
+++ b/packages/website/app/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
-import { Parser } from "./Parser";
 import Link from "next/link";
+
+import { PayloadViewerClientWrapper } from "./PayloadViewerClientWrapper";
 
 export const metadata: Metadata = {
   title: "RSC Parser",
@@ -8,29 +9,31 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <main className="flex flex-col items-center gap-8 py-12 md:gap-12">
-      <div className="flex w-full max-w-5xl flex-col gap-6 px-4">
-        <h1 className="text-3xl font-medium">RSC parser</h1>
-        <div className="flex flex-col gap-2">
-          <p>
-            This is a parser for React Server Components (RSC) when sent over
-            the network. React uses a format to represent a tree of
-            components/html or metadata such as required imports, suspense
-            boundaries, and css/fonts that needs to be loaded.
-          </p>
-          <p>
-            See the{" "}
-            <Link
-              href="https://github.com/alvarlagerlof/rsc-parser"
-              className="text-blue-700 dark:text-blue-500"
-            >
-              Github Repo
-            </Link>{" "}
-            for more information.
-          </p>
-        </div>
+    <main className="flex flex-col items-center py-12 ">
+      <div className="flex w-full max-w-7xl flex-col gap-12 px-4">
+        <section className="flex flex-col gap-4">
+          <h1 className="text-3xl font-medium">RSC parser</h1>
+          <div className="flex flex-col gap-2">
+            <p>
+              This is a parser for React Server Components (RSC) when sent over
+              the network. React uses a format to represent a tree of
+              components/html or metadata such as required imports, suspense
+              boundaries, and css/fonts that needs to be loaded.
+            </p>
+            <p>
+              See the{" "}
+              <Link
+                href="https://github.com/alvarlagerlof/rsc-parser"
+                className="text-blue-700 dark:text-blue-500"
+              >
+                Github Repo
+              </Link>{" "}
+              for more information.
+            </p>
+          </div>
+        </section>
+        <PayloadViewerClientWrapper />
       </div>
-      <Parser />
     </main>
   );
 }


### PR DESCRIPTION
This change introduces the `viewer` folder in core, meant for basically complete apps that don't need much or anything to be ran.

The new `PayloadViewer` is meant to be ran on the website, replacing `Parser`. It contains all of the interactive functionality of the website.

I've also added stories for various default payloads.