### PR TITLE
Fix fetch-patch when fetch is called with only an URL

### DIFF
--- a/packages/chrome-extension/public/fetch-patch.js
+++ b/packages/chrome-extension/public/fetch-patch.js
@@ -9,10 +9,17 @@ window.fetch = async (...args) => {
   let headers = undefined;
   if (args[0] instanceof Request) {
     url = args[0].url;
-    headers = args[0].headers;
+    if (typeof args[0].headers !== "undefined") {
+      headers = args[0].headers;
+    }
   } else if (typeof args[0] === "string" || args[0] instanceof URL) {
     url = args[0].toString();
-    headers = args[1].headers;
+    if (
+      typeof args[1] !== "undefined" &&
+      typeof args[1].headers !== "undefined"
+    ) {
+      headers = args[1].headers;
+    }
   }
 
   const response = await window.originalFetch(...args);


### PR DESCRIPTION
Sometimes there is a `fetch("url")` with no extra params like headers. The code previously failed to handle.

This resulted in breaking fetching for some sites like https://youtube.com and https://caniuse.com. Those sites now work again.