### PR TITLE
Remove unused error boundary fallback component

### DIFF
--- a/packages/website/app/GenericErrorBoundaryFallback.tsx
+++ b/packages/website/app/GenericErrorBoundaryFallback.tsx
@@ -1,8 +1,0 @@
-export function GenericErrorBoundaryFallback({ error }: { error: Error }) {
-  return (
-    <div role="alert" className="rounded-lg bg-red-100 p-4">
-      <p>Something went wrong:</p>
-      <pre className="text-red-600">{error.message}</pre>
-    </div>
-  );
-}


### PR DESCRIPTION
Was used before, but is not imported anywhere now.