### PR TITLE
Refactor fetch-patch to read the `Content-Type: text/x-component` header

### DIFF
--- a/packages/chrome-extension/public/fetch-patch.js
+++ b/packages/chrome-extension/public/fetch-patch.js
@@ -5,6 +5,26 @@ if (typeof window.originalFetch === "undefined") {
 window.fetch = async (...args) => {
   const fetchStartTime = Date.now();
 
+  const response = await window.originalFetch(...args);
+
+  if (typeof response.headers === "undefined") {
+    return response;
+  }
+
+  if (!response.headers.has("Content-Type")) {
+    return response;
+  }
+
+  if (response.headers.get("Content-Type") !== "text/x-component") {
+    return response;
+  }
+
+  const clonedResponse = response.clone();
+  const reader = clonedResponse.body
+    // eslint-disable-next-line no-undef
+    .pipeThrough(new TextDecoderStream())
+    .getReader();
+
   let url = undefined;
   let headers = undefined;
   if (args[0] instanceof Request) {
@@ -21,26 +41,6 @@ window.fetch = async (...args) => {
       headers = args[1].headers;
     }
   }
-
-  const response = await window.originalFetch(...args);
-
-  if (typeof headers === "undefined" || typeof headers === "undefined") {
-    return response;
-  }
-
-  if (headers instanceof Headers && !headers.has("RSC")) {
-    return response;
-  }
-
-  if (headers instanceof Object && typeof headers["RSC"] === "undefined") {
-    return response;
-  }
-
-  const clonedResponse = response.clone();
-  const reader = clonedResponse.body
-    // eslint-disable-next-line no-undef
-    .pipeThrough(new TextDecoderStream())
-    .getReader();
 
   // eslint-disable-next-line no-constant-condition
   while (true) {

--- a/packages/chrome-extension/public/fetch-patch.js
+++ b/packages/chrome-extension/public/fetch-patch.js
@@ -19,12 +19,6 @@ window.fetch = async (...args) => {
     return response;
   }
 
-  const clonedResponse = response.clone();
-  const reader = clonedResponse.body
-    // eslint-disable-next-line no-undef
-    .pipeThrough(new TextDecoderStream())
-    .getReader();
-
   let url = undefined;
   let headers = undefined;
   if (args[0] instanceof Request) {
@@ -41,6 +35,12 @@ window.fetch = async (...args) => {
       headers = args[1].headers;
     }
   }
+
+  const clonedResponse = response.clone();
+  const reader = clonedResponse.body
+    // eslint-disable-next-line no-undef
+    .pipeThrough(new TextDecoderStream())
+    .getReader();
 
   // eslint-disable-next-line no-constant-condition
   while (true) {


### PR DESCRIPTION
Instead of looking for `RSC: 1` in the request headers (a Next.js-specific thing), we can look for `Content-Type: text/x-component` in response headers.

This works well, and will be compatible with more frameworks down the line too.

With this change, extracting the url and request headers can be moved further down into the script. This is good because the earlier the script can return an unmodified response to the website code, the smaller the risk is that something unexpected crashes. Now there's just three simple if cases that each have early returns in case the conditions for RSC parsing are not fulfilled.