### PR TITLE
Remove unused manifest.json permissions

### DIFF
--- a/packages/chrome-extension/public/manifest.json
+++ b/packages/chrome-extension/public/manifest.json
@@ -2,8 +2,6 @@
   "name": "RSC Devtools",
   "version": "0.0.1",
   "description": "React Server Components network visualizer",
-  "permissions": ["webRequest"],
-  "host_permissions": ["*://*/*"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' http://localhost:6020; object-src 'self'"
   },


### PR DESCRIPTION
Turns out, neither `webRequest` nor `host_permissions` was needed.