### PR TITLE
Remove vite dev server from script exception from build manifest.json

### DIFF
--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern \"/dist\"/",
     "format": "prettier . --check --config ../../.prettierrc",
     "dev": "vite build --mode development && vite dev",
-    "build": "vite build && sed -i 's| http://localhost:6020||g' dist/manifest.json",
+    "build": "vite build && sed -i'.backup' 's| http://localhost:6020||g' dist/manifest.json && rm dist/manifest.json.backup",
     "release": "zip -r dist.zip dist"
   },
   "type": "module"

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern \"/dist\"/",
     "format": "prettier . --check --config ../../.prettierrc",
     "dev": "vite build --mode development && vite dev",
-    "build": "vite build",
+    "build": "vite build && sed -i '' 's| http://localhost:6020||g' dist/manifest.json",
     "release": "zip -r dist.zip dist"
   },
   "type": "module"

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern \"/dist\"/",
     "format": "prettier . --check --config ../../.prettierrc",
     "dev": "vite build --mode development && vite dev",
-    "build": "vite build && sed -i '' 's| http://localhost:6020||g' dist/manifest.json",
+    "build": "vite build && sed -i 's| http://localhost:6020||g' dist/manifest.json",
     "release": "zip -r dist.zip dist"
   },
   "type": "module"


### PR DESCRIPTION
The way that I've set up Vite HRM relies on ` http://localhost:6020` being part of `content_security_policy.extension_pages` when developing. This allows the extension to talk to the dev server.

But in production, all needed files are included in the dist, and localhost should not not be mentioned in the manifest.json. So I asked ChatGPT to help me write a script to remove it from the manifest.json in the dist. And tested it locally.

Since this is the only change that needs to happen between dev and prod I think this is acceptable for now, but looking into generating the manifest.json might be a good idea later.