### PR TITLE
Don't intercept stream if url or headers are missing

### DIFF
--- a/packages/chrome-extension/public/fetch-patch.js
+++ b/packages/chrome-extension/public/fetch-patch.js
@@ -36,6 +36,12 @@ window.fetch = async (...args) => {
     }
   }
 
+  if (!url || !headers) {
+    return response;
+  }
+
+  console.log("url", url);
+
   const clonedResponse = response.clone();
   const reader = clonedResponse.body
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
Seems like this fixes #258. There could be more to it, but I'm now able to navigate to https://gh-issues.vercel.app/issues without a crash.

<img width="1500" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/b7cb7e76-78e2-4f96-80d2-f0f711aaf5d7">