### PR TITLE
Improve error boundary in dark mode

### DIFF
--- a/packages/chrome-extension/src/BasicErrorBoundary.tsx
+++ b/packages/chrome-extension/src/BasicErrorBoundary.tsx
@@ -6,8 +6,8 @@ function fallbackRender({ error }: { error: Error }) {
 
   return (
     <div role="alert">
-      <p>Something went wrong:</p>
-      <pre className="text-red-300">{error.message}</pre>
+      <p className="dark:text-white">Something went wrong:</p>
+      <pre className="text-red-600 dark:text-red-400">{error.message}</pre>
     </div>
   );
 }

--- a/packages/core/src/GenericErrorBoundaryFallback.tsx
+++ b/packages/core/src/GenericErrorBoundaryFallback.tsx
@@ -3,8 +3,8 @@ import React from "react";
 export function GenericErrorBoundaryFallback({ error }: { error: Error }) {
   return (
     <div role="alert" className="rounded-lg bg-red-100 p-4 dark:text-white">
-      <p>Something went wrong:</p>
-      <pre className="text-red-600">{error.message}</pre>
+      <p className="dark:text-white">Something went wrong:</p>
+      <pre className="text-red-600 dark:text-red-400">{error.message}</pre>
     </div>
   );
 }


### PR DESCRIPTION
# Before
![image](https://github.com/alvarlagerlof/rsc-parser/assets/14835120/fa384af3-5852-4f00-be43-88d793ec015e)


# After
<img width="343" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/51dc7302-0d37-416e-b8ea-dbeda92f5362">
