### PR TITLE
Add a "Rows" tab

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -4,7 +4,7 @@ import { HintRow } from "./rows/HintRow";
 import { TreeRow } from "./rows/TreeRow";
 import { RowTabs } from "./tabs/row/RowTabs";
 import { parse, refineRowType, lexer, splitToCleanRows } from "./parse";
-import { RawStream } from "./stream/RowStream";
+import { RawStream } from "./stream/RawStream";
 import { StreamViewer } from "./viewer/StreamViewer";
 import { PayloadViewer } from "./viewer/PayloadViewer";
 import { RscChunkMessage } from "./stream/message";

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -4,7 +4,7 @@ import { HintRow } from "./rows/HintRow";
 import { TreeRow } from "./rows/TreeRow";
 import { RowTabs } from "./tabs/row/RowTabs";
 import { parse, refineRowType, lexer, splitToCleanRows } from "./parse";
-import { RawStream } from "./stream/RawStream";
+import { RawStream } from "./stream/RowStream";
 import { StreamViewer } from "./viewer/StreamViewer";
 import { PayloadViewer } from "./viewer/PayloadViewer";
 import { RscChunkMessage } from "./stream/message";

--- a/packages/core/src/stream/RowStream.stories.tsx
+++ b/packages/core/src/stream/RowStream.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { RowStream } from "./RowStream";
+import { nextJsExampleData } from "../example-data/nextjs";
+import { ghNextExampleData } from "../example-data/gh-next";
+import { neurodiversityWikiExampleData } from "../example-data/neurodiversity-wiki";
+
+const meta: Meta<typeof RowStream> = {
+  component: RowStream,
+};
+
+export default meta;
+type Story = StoryObj<typeof RowStream>;
+
+export const NextJs: Story = {
+  name: "nextjs.org",
+  args: {
+    messages: nextJsExampleData,
+  },
+};
+
+export const GhNext: Story = {
+  name: "gh-issues.vercel.app",
+  args: {
+    messages: ghNextExampleData,
+  },
+};
+
+export const NeurodiversityWiki: Story = {
+  name: "neurodiversity.wiki",
+  args: {
+    messages: neurodiversityWikiExampleData,
+  },
+};

--- a/packages/core/src/stream/RowStream.tsx
+++ b/packages/core/src/stream/RowStream.tsx
@@ -1,0 +1,18 @@
+import { RscChunkMessage } from "./message";
+
+export function RowStream({ messages }: { messages: RscChunkMessage[] }) {
+  const splitByRows = messages
+    .map((message) => message.data.chunkValue)
+    .join()
+    .split("\n");
+
+  return (
+    <ul className="flex flex-col gap-4 font-code dark:text-white">
+      {splitByRows.map((row) => (
+        <li>
+          <pre className="w-full whitespace-break-spaces break-all">{row}</pre>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/core/src/viewer/StreamViewer.tsx
+++ b/packages/core/src/viewer/StreamViewer.tsx
@@ -10,6 +10,7 @@ import { PathTabs, usePathTabs } from "../tabs/path/PathTabs";
 import { RowTabs } from "../tabs/row/RowTabs";
 import * as Ariakit from "@ariakit/react";
 import { RawStream } from "../stream/RawStream";
+import { RowStream } from "../stream/RowStream";
 
 export function StreamViewer({ messages }: { messages: RscChunkMessage[] }) {
   const defaultSelectedId = "parsed";
@@ -66,6 +67,12 @@ export function StreamViewer({ messages }: { messages: RscChunkMessage[] }) {
                   Parsed
                 </Ariakit.Tab>
                 <Ariakit.Tab
+                  id="rows"
+                  className="rounded-md px-2 py-0.5 aria-selected:bg-slate-300 dark:text-white dark:aria-selected:text-black"
+                >
+                  Rows
+                </Ariakit.Tab>
+                <Ariakit.Tab
                   id="raw"
                   className="rounded-md px-2 py-0.5 aria-selected:bg-slate-300 dark:text-white dark:aria-selected:text-black"
                 >
@@ -80,6 +87,9 @@ export function StreamViewer({ messages }: { messages: RscChunkMessage[] }) {
                     .map((message) => message.data.chunkValue)
                     .join()}
                 />
+              </Ariakit.TabPanel>
+              <Ariakit.TabPanel store={tab}>
+                <RowStream messages={messagesForCurrentTab} />
               </Ariakit.TabPanel>
               <Ariakit.TabPanel store={tab}>
                 <RawStream messages={messagesForCurrentTab} />


### PR DESCRIPTION
To fill the gap that Chrome leaves due to the streaming rendering failing, I added a "Rows" mode, that renders the stream pretty much as chrome would show it, with some notable improvements:

- There's a gap between newlines
- Rows wrap so that you don't have to scroll horizontally

This tab should be easy to select and copy into other tools to debug if wanted.

Fixes #227