### PR TITLE
Fix tree data parsing when null

### DIFF
--- a/packages/core/src/parse.spec.ts
+++ b/packages/core/src/parse.spec.ts
@@ -223,4 +223,16 @@ describe("parser", () => {
       data: `"[{"a":"b"},{"foo":"bar"}]"`,
     });
   });
+
+  it("should parse null", () => {
+    const row = `0:null`;
+    const tokens = lexer(row);
+    const result = parse(tokens);
+
+    expect(result).toStrictEqual({
+      identifier: "0",
+      type: "",
+      data: "null",
+    });
+  });
 });

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -25,6 +25,7 @@ export const LEFT_BRACE = "LEFT_BRACE" as const;
 export const LEFT_BRACKET = "LEFT_BRACKET" as const;
 export const RIGHT_BRACE = "RIGHT_BRACE" as const;
 export const RIGHT_BRACKET = "RIGHT_BRACKET" as const;
+export const LETTER_N = "LETTER_N" as const; // for null being sent as a tree type
 export const UNKNOWN = "UNKNOWN" as const;
 
 export function lexer(row: string) {
@@ -62,6 +63,11 @@ export function lexer(row: string) {
           type: RIGHT_BRACE,
           value: char,
         };
+      case "n":
+        return {
+          type: LETTER_N,
+          value: char,
+        };
       default:
         return {
           type: UNKNOWN,
@@ -90,7 +96,8 @@ export function parse(tokens: ReturnType<typeof lexer>) {
       (token) =>
         token.type === "DOUBLE_QUOTE" ||
         token.type === "LEFT_BRACE" ||
-        token.type === "LEFT_BRACKET",
+        token.type === "LEFT_BRACKET" ||
+        token.type === "LETTER_N",
     );
     const tokensBetweenColonAndJson = tokens.slice(
       firstColonIndex + 1,
@@ -106,7 +113,8 @@ export function parse(tokens: ReturnType<typeof lexer>) {
       (token) =>
         token.type === "DOUBLE_QUOTE" ||
         token.type === "LEFT_BRACE" ||
-        token.type === "LEFT_BRACKET",
+        token.type === "LEFT_BRACKET" ||
+        token.type === "LETTER_N",
     );
     const tokensAfterJsonStart = tokens.slice(firstJsonStartIndex);
     const data = tokensAfterJsonStart.map((token) => token.value).join("");


### PR DESCRIPTION
Recently I discovered some rows that are: `5:null` for example. The parser didn't handle this, leading to a crash in the `RowTab` rendering for those rows.

I'm not to happy about the solution. It assumes that there are no other row types that start with `n`. I haven't found any yet, but this solution likely won't hold up long-term.