### PR TITLE
Fix light mode PathTabs handle color

### DIFF
--- a/packages/core/src/tabs/path/PathTabs.tsx
+++ b/packages/core/src/tabs/path/PathTabs.tsx
@@ -91,7 +91,7 @@ export function PathTabs({
         </Ariakit.TabList>
       </Panel>
 
-      <PanelResizeHandle className="w-1 rounded bg-slate-600" />
+      <PanelResizeHandle className="w-1 rounded bg-slate-200 dark:bg-slate-800" />
 
       <Panel order={2} minSize={350} className="dark:text-white">
         <Ariakit.TabPanel


### PR DESCRIPTION
<img width="887" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/dfc2606e-735e-4a62-af9b-7ad78af84043">
