### PR TITLE
Add Turborepo setup for `dev` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "format": "turbo run format",
-    "ci": "turbo run ci"
+    "ci": "turbo run ci",
+    "dev": "turbo run dev"
   },
   "packageManager": "yarn@3.6.4",
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,8 +6,9 @@
   "license": "MIT",
   "scripts": {
     "build": "vite build && yarn tailwindcss -o dist/style.css --minify",
-    "dev": "concurrently  \"vite build --watch\" \"yarn tailwindcss -o dist/style.css --minify --watch\"",
+    "dev:build": "concurrently  \"vite build --watch\" \"yarn tailwindcss -o dist/style.css --minify --watch\"",
     "storybook": "storybook dev -p 6006 --no-open",
+    "dev": "concurrently  \"yarn dev:build\" \"yarn storybook\"",
     "build-storybook": "storybook build",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
     "test:dev": "yarn test --watch",

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,7 @@
     "format": {},
     "ci": {
       "dependsOn": ["build", "lint", "test", "format"]
-    }
+    },
+    "dev": {}
   }
 }


### PR DESCRIPTION
Previously it wasn't possible to run `dev` in the terminal to start all of the dev server. Now it is.