### PR TITLE
Fix extension resetting when clicking links

### DIFF
--- a/packages/chrome-extension/public/content-script.js
+++ b/packages/chrome-extension/public/content-script.js
@@ -43,7 +43,7 @@ window.addEventListener(
 );
 
 // When the content script is unloaded (like for a refresh), send a message to the devtools panel to reset it
-window.addEventListener("load", () => {
+window.addEventListener("beforeunload", () => {
   // eslint-disable-next-line no-undef
   chrome.runtime.sendMessage({ type: "CONTENT_SCRIPT_LOADED" });
 });


### PR DESCRIPTION
Previously, the extension was resetting quite often when you clicked links due to the "load" event unexpectedly firing. This caused a bad experience because it was resetting the extension state. By using the "unload" event instead, it doesn't reload too often.