### PR TITLE
Flatten `NodeOther` into `Node`

### DIFF
--- a/packages/core/src/react/ReactFlightClient.ts
+++ b/packages/core/src/react/ReactFlightClient.ts
@@ -125,7 +125,7 @@ export type FlightResponse = {
   _fromJSON: (key: string, value: JSONValue) => any;
 };
 
-type ParsedObject = {
+export type ParsedObject = {
   $$type: "parsedObject";
   id: string;
   identifier: string;


### PR DESCRIPTION
I realized that `NodeOther` could be flattened into `Node`.  This has the benefit of there only being one main place where switching is happening instead of two.

To make this easier, I created `JSContainerWrapperForObjects` that wraps `JSContainer` as needed based on the `ObjectContext`.

Then I also re-ordered the components a bit to make the order match the `NodeSwitch` more closely.