### PR TITLE
Rename `ParsedObject` to `Reference`

### DIFF
--- a/packages/core/src/components/FlightResponseChunkModel.tsx
+++ b/packages/core/src/components/FlightResponseChunkModel.tsx
@@ -11,10 +11,10 @@ import { ErrorBoundary } from "react-error-boundary";
 import { GenericErrorBoundaryFallback } from "./GenericErrorBoundaryFallback.jsx";
 import { DownArrowIcon, RightArrowIcon } from "./FlightResponseIcons.jsx";
 import {
-  ParsedObject,
   createElement,
+  Reference,
   isElement,
-  isParsedObject,
+  isReference,
 } from "../react/ReactFlightClient.js";
 
 export const ClickIDContext = createContext<{
@@ -59,8 +59,8 @@ function NodeSwitch({ value }: { value: unknown }) {
     return <NodeArray value={value} />;
   }
 
-  if (isParsedObject(value)) {
-    return <NodeParsedObject value={value} />;
+  if (isReference(value)) {
+    return <NodeReference value={value} />;
   }
 
   if (value instanceof Set) {
@@ -302,7 +302,7 @@ function Prop({ propKey, value }: { propKey: string; value: unknown }) {
 }
 
 function Props({ props }: { props: { [key: string]: unknown } }) {
-  if (isParsedObject(props)) {
+  if (isReference(props)) {
     return (
       <div className="pl-[3ch]">
         <Node value={props} />
@@ -384,7 +384,7 @@ function NodeArray({ value }: { value: unknown[] }) {
   );
 }
 
-function NodeParsedObject({ value }: { value: ParsedObject }) {
+function NodeReference({ value }: { value: Reference }) {
   return (
     <span className="inline-flex flex-row gap-2">
       <TabJumpButton destinationTab={value.id}>

--- a/packages/core/src/react/ReactFlightClient.ts
+++ b/packages/core/src/react/ReactFlightClient.ts
@@ -125,19 +125,19 @@ export type FlightResponse = {
   _fromJSON: (key: string, value: JSONValue) => any;
 };
 
-export type ParsedObject = {
-  $$type: "parsedObject";
+export type Reference = {
+  $$type: "reference";
   id: string;
   identifier: string;
   type: string;
 };
 
-export function isParsedObject(x: unknown): x is ParsedObject {
+export function isReference(x: unknown): x is Reference {
   return (
     typeof x === "object" &&
     x !== null &&
     "$$type" in x &&
-    x.$$type === "parsedObject"
+    x.$$type === "reference"
   );
 }
 
@@ -166,11 +166,11 @@ function parseModelString(
         // return createLazyChunkWrapper(chunk);
 
         return {
-          $$type: "parsedObject",
+          $$type: "reference",
           id: new Number(id).toString(16),
           identifier: "L",
           type: "Lazy node",
-        } satisfies ParsedObject;
+        } satisfies Reference;
       }
       case "@": {
         // Promise
@@ -179,11 +179,11 @@ function parseModelString(
         // return chunk;
 
         return {
-          $$type: "parsedObject",
+          $$type: "reference",
           id: new Number(id).toString(16),
           identifier: "@",
           type: "Promise",
-        } satisfies ParsedObject;
+        } satisfies Reference;
       }
       case "S": {
         // Symbol
@@ -203,11 +203,11 @@ function parseModelString(
         // return createServerReferenceProxy(response, metadata);
 
         return {
-          $$type: "parsedObject",
+          $$type: "reference",
           id: new Number(id).toString(16),
           identifier: "F",
           type: "Server Reference",
-        } satisfies ParsedObject;
+        } satisfies Reference;
       }
       case "Q": {
         // Map
@@ -216,11 +216,11 @@ function parseModelString(
         // return new Map(data);
 
         return {
-          $$type: "parsedObject",
+          $$type: "reference",
           id: new Number(id).toString(16),
           identifier: "Q",
           type: "Map",
-        } satisfies ParsedObject;
+        } satisfies Reference;
       }
       case "W": {
         // Set
@@ -229,11 +229,11 @@ function parseModelString(
         // return new Set(data);
 
         return {
-          $$type: "parsedObject",
+          $$type: "reference",
           id: new Number(id).toString(16),
           identifier: "W",
           type: "Set",
-        } satisfies ParsedObject;
+        } satisfies Reference;
       }
       case "I": {
         // $Infinity
@@ -300,11 +300,11 @@ function parseModelString(
         // }
 
         return {
-          $$type: "parsedObject",
+          $$type: "reference",
           id: new Number(id).toString(16),
           identifier: "",
           type: "Reference",
-        } satisfies ParsedObject;
+        } satisfies Reference;
       }
     }
   }


### PR DESCRIPTION
`ParsedObject` is a bit of custom data that is added to make finding references easier.

It makes more sense to call these things references, because that's really wat they are.