### PR TITLE
Add support for debug info chunks

### DIFF
--- a/packages/core/src/components/FlightResponseChunkDebugInfo.tsx
+++ b/packages/core/src/components/FlightResponseChunkDebugInfo.tsx
@@ -1,0 +1,9 @@
+import { DebugInfoChunk } from "../react/ReactFlightClient";
+
+export function FlightResponseChunkDebugInfo({
+  data,
+}: {
+  data: DebugInfoChunk["value"];
+}) {
+  return <p>React component name: {data.name}</p>;
+}

--- a/packages/core/src/components/FlightResponseChunkRaw.tsx
+++ b/packages/core/src/components/FlightResponseChunkRaw.tsx
@@ -3,7 +3,9 @@ import { Chunk } from "../react/ReactFlightClient";
 export function FlightResponseChunkRaw({ data }: { data: Chunk }) {
   return (
     <pre className="w-full whitespace-break-spaces break-all">
-      {data.originalValue}
+      {typeof data.originalValue === "string"
+        ? data.originalValue
+        : JSON.stringify(data.originalValue, null, 2)}
     </pre>
   );
 }

--- a/packages/core/src/components/FlightResponseTabSplit.tsx
+++ b/packages/core/src/components/FlightResponseTabSplit.tsx
@@ -283,6 +283,8 @@ function RowTabPanelExplorer({
     }
     case "text":
       return <p>{row.value}</p>;
+    case "debugInfo":
+      return <pre>{JSON.stringify(row.value, null, 2)}</pre>;
     default: {
       return null;
     }

--- a/packages/core/src/components/FlightResponseTabSplit.tsx
+++ b/packages/core/src/components/FlightResponseTabSplit.tsx
@@ -9,6 +9,7 @@ import { FlightResponseChunkHint } from "./FlightResponseChunkHint";
 import { FlightResponseChunkModel } from "./FlightResponseChunkModel";
 import { DownArrowIcon, RightArrowIcon } from "./FlightResponseIcons";
 import { EndTimeContext } from "./ViewerStreams";
+import { FlightResponseChunkDebugInfo } from "./FlightResponseChunkDebugInfo";
 
 export function FlightResponseTabSplit({
   flightResponse,
@@ -284,7 +285,7 @@ function RowTabPanelExplorer({
     case "text":
       return <p>{row.value}</p>;
     case "debugInfo":
-      return <pre>{JSON.stringify(row.value, null, 2)}</pre>;
+      return <FlightResponseChunkDebugInfo data={row.value} />;
     default: {
       return null;
     }


### PR DESCRIPTION
Based on changes in https://github.com/facebook/react/pull/28272/files, the code should now be able to render debug info chunks. For now, it's not connecting them to components, but you will at least be able to see them.

<img width="605" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/fb1aa1ca-6f1f-4254-86cb-f1e9a3b34dc6">
