### PR TITLE
Rsolve debug info regardless of __DEV__

### DIFF
--- a/packages/core/src/react/ReactFlightClient.ts
+++ b/packages/core/src/react/ReactFlightClient.ts
@@ -813,16 +813,16 @@ function processFullRow(
       return;
     }
     case 68 /* "D" */: {
-      if (__DEV__) {
-        const debugInfo = JSON.parse(row);
-        resolveDebugInfo(response, id, debugInfo);
-        return;
-      }
-      throw new Error(
-        "Failed to read a RSC payload created by a development version of React " +
-          "on the server while using a production version on the client. Always use " +
-          "matching versions on the server and the client.",
-      );
+      //if (__DEV__) {
+      const debugInfo = JSON.parse(row);
+      resolveDebugInfo(response, id, debugInfo);
+      return;
+      //}
+      // throw new Error(
+      //   "Failed to read a RSC payload created by a development version of React " +
+      //     "on the server while using a production version on the client. Always use " +
+      //     "matching versions on the server and the client.",
+      // );
     }
     case 80 /* "P" */: {
       if (enablePostpone) {


### PR DESCRIPTION
Currently, the version of ReactFlightClient in this repo does have `__DEV__` but it's not matching the state of the website that it's reading from, so we have to assume that we can read debug info even if we might not be able to.