### PR TITLE
Use `row` instead of `chunk` in FlightResponseTabSplit

### DIFF
--- a/.changeset/few-planets-doubt.md
+++ b/.changeset/few-planets-doubt.md
@@ -1,0 +1,7 @@
+---
+"@rsc-parser/core": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/website": patch
+---
+
+Use `chunk` name instead of `row`


### PR DESCRIPTION
Using `chunk` is more consistent with the type name.