### PR TITLE
Move EndTimeContext to its own file

### DIFF
--- a/packages/core/src/components/EndTimeContext.tsx
+++ b/packages/core/src/components/EndTimeContext.tsx
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const EndTimeContext = createContext<number>(Infinity);

--- a/packages/core/src/components/FlightResponseTabNetwork.tsx
+++ b/packages/core/src/components/FlightResponseTabNetwork.tsx
@@ -1,7 +1,7 @@
 import { Chunk, FlightResponse, isReference } from "../react/ReactFlightClient";
 import React, { memo, useContext, useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
-import { EndTimeContext } from "./ViewerStreams";
+import { EndTimeContext } from "./EndTimeContext";
 
 interface Node extends d3.SimulationNodeDatum {
   chunk: Chunk;

--- a/packages/core/src/components/FlightResponseTabRaw.tsx
+++ b/packages/core/src/components/FlightResponseTabRaw.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { FlightResponse } from "../react/ReactFlightClient";
 import { FlightResponseChunkRaw } from "./FlightResponseChunkRaw";
-import { EndTimeContext } from "./ViewerStreams";
+import { EndTimeContext } from "./EndTimeContext";
 
 export function FlightResponseTabRaw({
   flightResponse,

--- a/packages/core/src/components/FlightResponseTabSplit.tsx
+++ b/packages/core/src/components/FlightResponseTabSplit.tsx
@@ -8,7 +8,7 @@ import { FlightResponseChunkModule } from "./FlightResponseChunkModule";
 import { FlightResponseChunkHint } from "./FlightResponseChunkHint";
 import { FlightResponseChunkModel } from "./FlightResponseChunkModel";
 import { DownArrowIcon, RightArrowIcon } from "./FlightResponseIcons";
-import { EndTimeContext } from "./ViewerStreams";
+import { EndTimeContext } from "./EndTimeContext";
 import { FlightResponseChunkDebugInfo } from "./FlightResponseChunkDebugInfo";
 import { FlightResponseChunkText } from "./FlightResponseChunkText";
 import { FlightResponseChunkUnknown } from "./FlightResponseChunkUnknown";

--- a/packages/core/src/components/ViewerPayload.tsx
+++ b/packages/core/src/components/ViewerPayload.tsx
@@ -5,7 +5,7 @@ import { GenericErrorBoundaryFallback } from "./GenericErrorBoundaryFallback";
 import { createFlightResponse } from "../createFlightResponse";
 import { RscChunkMessage } from "../types";
 import { FlightResponse } from "./FlightResponse";
-import { EndTimeContext } from "./ViewerStreams";
+import { EndTimeContext } from "./EndTimeContext";
 
 export function ViewerPayload({ defaultPayload }: { defaultPayload: string }) {
   const [payload, setPayload] = useState(defaultPayload);

--- a/packages/core/src/components/ViewerStreams.tsx
+++ b/packages/core/src/components/ViewerStreams.tsx
@@ -1,4 +1,4 @@
-import React, { createContext } from "react";
+import React from "react";
 import { createFlightResponse } from "../createFlightResponse";
 import { RscChunkMessage } from "../types";
 import { FlightResponse } from "./FlightResponse";
@@ -8,6 +8,7 @@ import {
 } from "./FlightResponseSelector";
 import { TimeScrubber, useTimeScrubber } from "./TimeScrubber";
 import { useFilterMessagesByEndTime, useGroupedMessages } from "./TimeScrubber";
+import { EndTimeContext } from "./EndTimeContext";
 
 export function ViewerStreams({ messages }: { messages: RscChunkMessage[] }) {
   const timeScrubber = useTimeScrubber(messages, {
@@ -46,5 +47,3 @@ export function ViewerStreams({ messages }: { messages: RscChunkMessage[] }) {
     </div>
   );
 }
-
-export const EndTimeContext = createContext<number>(Infinity);


### PR DESCRIPTION
Noticed in #848 that it was creating a dependency cycle.