### PR TITLE
Create a `useRscMessages` hook

### DIFF
--- a/.changeset/yellow-boxes-collect.md
+++ b/.changeset/yellow-boxes-collect.md
@@ -1,0 +1,8 @@
+---
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/core": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Create a `useRscMessages` hook


### PR DESCRIPTION
In @rsc-parser/chrome-extension, I created a hook called `useRscMessages` which contains the logic for recording RSC payloads.