### PR TITLE
Make @rsc-parser/core dependency in @rsc-parser/embedded a dev dependency

### DIFF
--- a/.changeset/cuddly-paws-sing.md
+++ b/.changeset/cuddly-paws-sing.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/core": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Make @rsc-parser/core dependency in @rsc-parser/embedded a dev dependency

--- a/packages/embedded/package.json
+++ b/packages/embedded/package.json
@@ -22,12 +22,12 @@
     "dist"
   ],
   "dependencies": {
-    "@rsc-parser/core": "workspace:^",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@rsc-parser/core": "workspace:^",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^9.0.0",
     "react": "18.2.0",


### PR DESCRIPTION


Wasn't able to install @rsc-parser/embedded in a different project because it depended on a `workspace:*` package.