### PR TITLE
Remove <head> tag for styling in RscDevtoolsPanel

### DIFF
--- a/.changeset/orange-trains-doubt.md
+++ b/.changeset/orange-trains-doubt.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/core": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Stop wrapping <style> in <head> in RscDevtoolsPanel

--- a/packages/embedded/RscDevtoolsPanel.tsx
+++ b/packages/embedded/RscDevtoolsPanel.tsx
@@ -84,9 +84,7 @@ function ApplyStylingOnClient({ children }: { children: ReactNode }) {
 
   return (
     <>
-      <head>
-        <style>{styles}</style>
-      </head>
+      <style>{styles}</style>
       {children}
     </>
   );


### PR DESCRIPTION
The `RscDevtoolsPanel` component adds styling automatically by rendering a `<style>` tag with inline css. It is currently wrapped in `<head>`, but it doesn't need to, and it caused an error.