### PR TITLE
Use :scope to contain Tailwind styles for `RscDevtoolsPanel`

### DIFF
--- a/.changeset/afraid-boats-punch.md
+++ b/.changeset/afraid-boats-punch.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/core": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Scope styles for RscDevtoolsPanel

--- a/packages/embedded/RscDevtoolsPanel.tsx
+++ b/packages/embedded/RscDevtoolsPanel.tsx
@@ -78,15 +78,33 @@ function ApplyStylingOnClient({ children }: { children: ReactNode }) {
     () => false,
   );
 
-  if (!isClient) {
+  const [polyfillIsLoaded, setPolyfillIsLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src = "https://unpkg.com/style-scoped@0/scoped.min.js";
+
+    script.addEventListener("load", () => {
+      setPolyfillIsLoaded(true);
+    });
+
+    document.head.appendChild(script);
+  }, [isClient]);
+
+  if (!isClient || !polyfillIsLoaded) {
     return null;
   }
 
   return (
-    <>
-      <style>{styles}</style>
+    <div>
+      <style scoped>{styles}</style>
       {children}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
They're currently leaking and interacting with other potential styles.

First I tried using [@scope](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope), which worked great in Chrome, but there is [no Firefox support](https://caniuse.com/css-cascade-scope). I tried finding a polyfill for it, but only found polyfills for the older `:scope`, so I went with [one of those](https://github.com/samthor/scoped) instead.