### PR TITLE
Move fetch patching code to @rsc-parser/core

### DIFF
--- a/.changeset/plenty-dingos-jam.md
+++ b/.changeset/plenty-dingos-jam.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/embedded": minor
+"@rsc-parser/core": minor
+"@rsc-parser/embedded-example": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Move fetch patching code to @rsc-parser/core

--- a/packages/chrome-extension/src/fetch-patch.ts
+++ b/packages/chrome-extension/src/fetch-patch.ts
@@ -1,78 +1,8 @@
-// @ts-expect-error TODO: Fix type
-if (typeof window.originalFetch === "undefined") {
-  // @ts-expect-error TODO: Fix type
-  window.originalFetch = window.fetch;
-}
+import { fetchPatcher } from "@rsc-parser/core";
 
-window.fetch = async (...args) => {
-  const fetchStartTime = Date.now();
-
-  // @ts-expect-error TODO: Fix type
-  const response = await window.originalFetch(...args);
-
-  if (typeof response.headers === "undefined") {
-    return response;
-  }
-
-  if (!response.headers.has("Content-Type")) {
-    return response;
-  }
-
-  if (response.headers.get("Content-Type") !== "text/x-component") {
-    return response;
-  }
-
-  let url = undefined;
-  let headers = undefined;
-  if (args[0] instanceof Request) {
-    url = args[0].url;
-    if (typeof args[0].headers !== "undefined") {
-      headers = args[0].headers;
-    }
-  } else if (typeof args[0] === "string" || args[0] instanceof URL) {
-    url = args[0].toString();
-    if (
-      typeof args[1] !== "undefined" &&
-      typeof args[1].headers !== "undefined"
-    ) {
-      headers = args[1].headers;
-    }
-  }
-
-  if (!url || !headers) {
-    return response;
-  }
-
-  const clonedResponse = response.clone();
-  const reader = clonedResponse.body.getReader();
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const chunkStartTime = Date.now();
-    const { value, done } = await reader.read();
-    if (done) {
-      break;
-    }
-    const chunkEndTime = Date.now();
-
-    window.postMessage(
-      {
-        type: "RSC_CHUNK",
-        data: {
-          fetchUrl: url,
-          fetchHeaders:
-            headers instanceof Headers
-              ? Object.fromEntries(headers.entries())
-              : headers,
-          fetchStartTime,
-          chunkValue: Array.from(value),
-          chunkStartTime,
-          chunkEndTime,
-        },
-      },
-      "*",
-    );
-  }
-
-  return response;
-};
+fetchPatcher({
+  onRscChunkMessage: (message) => {
+    // Forward the message so that the content script can pick it up
+    window.postMessage(message, "*");
+  },
+});

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 dist
+vite.config.ts.timestamp*

--- a/packages/core/src/components/ViewerPayload.tsx
+++ b/packages/core/src/components/ViewerPayload.tsx
@@ -54,9 +54,6 @@ function Viewer({ payload }: { payload: string }) {
       tabId: 0,
       data: {
         fetchUrl: "https://example.com",
-        fetchHeaders: {
-          "Content-Type": "application/json",
-        },
         fetchStartTime: 0,
         chunkStartTime: 0,
         chunkEndTime: 0,

--- a/packages/core/src/example-data/alvar-dev.ts
+++ b/packages/core/src/example-data/alvar-dev.ts
@@ -5,12 +5,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://www.alvar.dev/blog?_rsc=1sxgj",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526298,
       chunkValue: [
         50, 58, 73, 91, 50, 53, 50, 53, 48, 44, 91, 34, 53, 50, 53, 48, 34, 44,
@@ -34,12 +28,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://www.alvar.dev/blog?_rsc=1sxgj",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526298,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -457,12 +445,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://www.alvar.dev/blog?_rsc=1sxgj",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526298,
       chunkValue: [
         52, 58, 91, 34, 36, 34, 44, 34, 100, 105, 118, 34, 44, 110, 117, 108,
@@ -754,13 +736,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/thoughts-on-photography-tools?_rsc=18e5w",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2Cnull%2Ctrue%5D",
-        "Next-Router-Prefetch": "1",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526548,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -788,13 +763,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/always-add-name-to-type-radio?_rsc=18e5w",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2Cnull%2Ctrue%5D",
-        "Next-Router-Prefetch": "1",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526581,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -822,13 +790,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/tailwindcss-with-next-font?_rsc=18e5w",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2Cnull%2Ctrue%5D",
-        "Next-Router-Prefetch": "1",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526547,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -856,13 +817,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=18e5w",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2Cnull%2Ctrue%5D",
-        "Next-Router-Prefetch": "1",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526547,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -891,13 +845,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/skeleton-loading-with-suspense-in-next-js-13?_rsc=18e5w",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(main)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2Cnull%2Ctrue%5D",
-        "Next-Router-Prefetch": "1",
-        "Next-Url": "/blog",
-      },
       fetchStartTime: 1706448526547,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -926,12 +873,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(backnav)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%5B%22slug%22%2C%22creating-devtools-for-react-server-components%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D",
-        "Next-Url": "/blog/creating-devtools-for-react-server-components",
-      },
       fetchStartTime: 1706448528308,
       chunkValue: [
         51, 58, 73, 91, 53, 54, 49, 51, 44, 91, 93, 44, 34, 34, 93, 10, 53, 58,
@@ -1255,12 +1196,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(backnav)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%5B%22slug%22%2C%22creating-devtools-for-react-server-components%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D",
-        "Next-Url": "/blog/creating-devtools-for-react-server-components",
-      },
       fetchStartTime: 1706448528308,
       chunkValue: [
         56, 58, 73, 91, 56, 49, 57, 55, 50, 44, 91, 34, 53, 50, 53, 48, 34, 44,
@@ -3728,12 +3663,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(backnav)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%5B%22slug%22%2C%22creating-devtools-for-react-server-components%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D",
-        "Next-Url": "/blog/creating-devtools-for-react-server-components",
-      },
       fetchStartTime: 1706448528308,
       chunkValue: [
         49, 50, 58, 34, 36, 76, 49, 55, 34, 10, 49, 51, 58, 34, 36, 76, 49, 56,
@@ -3750,12 +3679,6 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(backnav)%22%2C%7B%22children%22%3A%5B%22blog%22%2C%7B%22children%22%3A%5B%5B%22slug%22%2C%22creating-devtools-for-react-server-components%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D",
-        "Next-Url": "/blog/creating-devtools-for-react-server-components",
-      },
       fetchStartTime: 1706448528308,
       chunkValue: [
         49, 55, 58, 91, 34, 36, 34, 44, 34, 100, 105, 118, 34, 44, 110, 117,

--- a/packages/core/src/example-data/gh-fredkiss-dev.ts
+++ b/packages/core/src/example-data/gh-fredkiss-dev.ts
@@ -5,12 +5,6 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=kvatu",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(app)%22%2C%7B%22header_subnav%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22page_title%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D%7D%5D%2C%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22actions%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D",
-        "Next-Url": "/children/Fredkiss3/gh-next/[...pages]",
-      },
       fetchStartTime: 1706451203109,
       chunkValue: [
         55, 58, 73, 91, 50, 48, 55, 48, 44, 91, 93, 44, 34, 34, 93, 10, 97, 58,
@@ -39,12 +33,6 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=kvatu",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(app)%22%2C%7B%22header_subnav%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22page_title%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D%7D%5D%2C%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22actions%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D",
-        "Next-Url": "/children/Fredkiss3/gh-next/[...pages]",
-      },
       fetchStartTime: 1706451203109,
       chunkValue: [
         48, 58, 91, 34, 103, 90, 86, 119, 81, 120, 87, 56, 117, 51, 50, 115, 71,
@@ -462,12 +450,6 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=kvatu",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(app)%22%2C%7B%22header_subnav%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22page_title%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D%7D%5D%2C%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22actions%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D",
-        "Next-Url": "/children/Fredkiss3/gh-next/[...pages]",
-      },
       fetchStartTime: 1706451203109,
       chunkValue: [
         50, 58, 91, 34, 36, 34, 44, 34, 110, 97, 118, 34, 44, 110, 117, 108,
@@ -655,12 +637,6 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=1326h",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(app)%22%2C%7B%22header_subnav%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D%7D%5D%2C%22page_title%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22actions%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D",
-        "Next-Url": "/children/Fredkiss3/gh-next/[...pages]",
-      },
       fetchStartTime: 1706451203252,
       chunkValue: [
         51, 58, 73, 91, 50, 48, 55, 48, 44, 91, 93, 44, 34, 34, 93, 10, 54, 58,
@@ -1056,12 +1032,6 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=1326h",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(app)%22%2C%7B%22header_subnav%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D%7D%5D%2C%22page_title%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22actions%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D",
-        "Next-Url": "/children/Fredkiss3/gh-next/[...pages]",
-      },
       fetchStartTime: 1706451203252,
       chunkValue: [
         55, 58, 91, 91, 34, 36, 34, 44, 34, 109, 101, 116, 97, 34, 44, 34, 48,
@@ -1287,12 +1257,6 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     type: "RSC_CHUNK",
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=1ho2t",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(app)%22%2C%7B%22header_subnav%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22page_title%22%3A%5B%22children%22%2C%7B%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22%5B...pages%5D%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22children%22%3A%5B%5B%22user%22%2C%22Fredkiss3%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%5B%22repository%22%2C%22gh-next%22%2C%22d%22%5D%2C%7B%22children%22%3A%5B%22actions%22%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%2Cnull%2C%22refetch%22%5D%7D%5D%7D%5D%7D%5D%7D%5D",
-        "Next-Url": "/children/Fredkiss3/gh-next/[...pages]",
-      },
       fetchStartTime: 1706451203373,
       chunkValue: [
         57, 58, 73, 91, 57, 57, 49, 52, 44, 91, 34, 57, 57, 49, 52, 34, 44, 34,

--- a/packages/core/src/example-data/nextjs-org.ts
+++ b/packages/core/src/example-data/nextjs-org.ts
@@ -6,13 +6,6 @@ export const nextjsOrgExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl:
         "https://nextjs.org/docs/app/building-your-application/routing?_rsc=2xhb5",
-      fetchHeaders: {
-        RSC: "1",
-        "Next-Router-State-Tree":
-          "%5B%22%22%2C%7B%22children%22%3A%5B%22(next-site)%22%2C%7B%22children%22%3A%5B%22docs%22%2C%7B%22children%22%3A%5B%5B%22slug%22%2C%22%22%2C%22oc%22%5D%2C%7B%22children%22%3A%5B%22__PAGE__%22%2C%7B%7D%5D%7D%5D%7D%5D%7D%2Cnull%2Cnull%2Ctrue%5D%7D%5D",
-        "Next-Router-Prefetch": "1",
-        "Next-Url": "/docs",
-      },
       fetchStartTime: 1706452689281,
       chunkValue: [
         50, 58, 73, 91, 49, 49, 49, 50, 57, 44, 91, 34, 53, 49, 53, 51, 34, 44,

--- a/packages/core/src/fetchPatcher.ts
+++ b/packages/core/src/fetchPatcher.ts
@@ -1,0 +1,67 @@
+import { RscChunkMessage } from "./types";
+
+function isRscResponse(response: Response): boolean {
+  return response.headers.get("Content-Type") === "text/x-component";
+}
+
+function getFetchUrl(args: Parameters<typeof fetch>): string {
+  if (args[0] instanceof Request) {
+    return args[0].url;
+  } else if (typeof args[0] === "string" || args[0] instanceof URL) {
+    return args[0].toString();
+  }
+
+  throw new Error("Unknown fetch argument");
+}
+
+export function fetchPatcher({
+  onRscChunkMessage,
+}: {
+  onRscChunkMessage: (message: RscChunkMessage) => void;
+}) {
+  // @ts-expect-error TODO: Fix type
+  if (typeof window.originalFetch === "undefined") {
+    // @ts-expect-error TODO: Fix type
+    window.originalFetch = window.fetch;
+  }
+
+  window.fetch = async (...args) => {
+    const fetchStartTime = Date.now();
+
+    // @ts-expect-error TODO: Fix type
+    const response = await window.originalFetch(...args);
+
+    if (!isRscResponse(response)) {
+      return response;
+    }
+
+    const url = getFetchUrl(args);
+
+    const clonedResponse = response.clone();
+    const reader = clonedResponse.body.getReader();
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const chunkStartTime = Date.now();
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      const chunkEndTime = Date.now();
+
+      onRscChunkMessage({
+        type: "RSC_CHUNK",
+        tabId: 0, // This may be overwritten extension code
+        data: {
+          fetchUrl: url,
+          fetchStartTime,
+          chunkValue: Array.from(value),
+          chunkStartTime,
+          chunkEndTime,
+        },
+      });
+    }
+
+    return response;
+  };
+}

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -12,6 +12,7 @@ import {
   BottomPanelOpenButton,
   BottomPanelCloseButton,
 } from "./components/BottomPanel";
+import { fetchPatcher } from "./fetchPatcher";
 
 export {
   type RscChunkMessage,
@@ -26,4 +27,5 @@ export {
   BottomPanel,
   BottomPanelOpenButton,
   BottomPanelCloseButton,
+  fetchPatcher,
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,7 +3,6 @@ export type RscChunkMessage = {
   tabId: number;
   data: {
     fetchUrl: string;
-    fetchHeaders: Record<string, string | undefined>;
     fetchStartTime: number;
     chunkValue: number[];
     chunkStartTime: number;

--- a/packages/embedded/.gitignore
+++ b/packages/embedded/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 dist
+vite.config.ts.timestamp*

--- a/packages/embedded/RscDevtoolsPanel.tsx
+++ b/packages/embedded/RscDevtoolsPanel.tsx
@@ -14,6 +14,7 @@ import {
   DebugCopyMessagesButton,
   ClearMessagesButton,
   PanelLayout,
+  fetchPatcher,
 } from "@rsc-parser/core";
 import React, {
   ReactNode,
@@ -117,95 +118,24 @@ function useRscMessages() {
       return;
     }
 
-    // @ts-expect-error TODO: fix this
-    if (typeof window.originalFetch === "undefined") {
-      // @ts-expect-error TODO: fix this
-      window.originalFetch = window.fetch;
-    }
-
-    window.fetch = async (...args) => {
-      const fetchStartTime = Date.now();
-
-      // @ts-expect-error TODO: fix this
-      const response = await window.originalFetch(...args);
-
-      if (typeof response.headers === "undefined") {
-        return response;
-      }
-
-      if (!response.headers.has("Content-Type")) {
-        return response;
-      }
-
-      if (response.headers.get("Content-Type") !== "text/x-component") {
-        return response;
-      }
-
-      let url = undefined;
-      let headers = undefined;
-      if (args[0] instanceof Request) {
-        url = args[0].url;
-        if (typeof args[0].headers !== "undefined") {
-          headers = args[0].headers;
-        }
-      } else if (typeof args[0] === "string" || args[0] instanceof URL) {
-        url = args[0].toString();
-        if (
-          typeof args[1] !== "undefined" &&
-          typeof args[1].headers !== "undefined"
-        ) {
-          headers = args[1].headers;
-        }
-      }
-
-      if (!url || !headers) {
-        return response;
-      }
-
-      const clonedResponse = response.clone();
-      const reader = clonedResponse.body.getReader();
-
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        const chunkStartTime = Date.now();
-        const { value, done } = await reader.read();
-        if (done) {
-          break;
-        }
-        const chunkEndTime = Date.now();
-
-        // It's possible that this lookup will miss a duplicated message if another
-        // one is being added at the same time. I haven't seen this happen in practice.
+    fetchPatcher({
+      onRscChunkMessage: (message) => {
         if (
           messages.some((item) =>
-            arraysEqual(item.data.chunkValue, Array.from(value)),
+            arraysEqual(
+              item.data.chunkValue,
+              Array.from(message.data.chunkValue),
+            ),
           )
         ) {
           return true;
         }
 
-        const message = {
-          type: "RSC_CHUNK",
-          data: {
-            fetchUrl: url,
-            fetchHeaders:
-              headers instanceof Headers
-                ? Object.fromEntries(headers.entries())
-                : headers,
-            fetchStartTime,
-            chunkValue: Array.from(value),
-            chunkStartTime,
-            chunkEndTime,
-          },
-        } as unknown as RscChunkMessage;
-
         startTransition(() => {
           setMessages((previous) => [...previous, message]);
         });
-      }
-
-      return response;
-    };
+      },
+    });
   }, [isRecording]);
 
   const startRecording = useCallback(() => {


### PR DESCRIPTION
Created a `fetchPatcher` function in `@rsc-parser/core` that has a callback function called `onRscChunkMessage`. This can then be used in both `@rsc-parser/embedded` and `@rsc-parser/chrome-extension`.

I've also decided to remove `fetchHeaders` from RscChunkMessage for now since it never got used.