### PR TITLE
Add a button to parse from `__next_f` from script tags in @rsc-parse/embedded

### DIFF
--- a/.changeset/nine-cobras-fly.md
+++ b/.changeset/nine-cobras-fly.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded": patch
+"@rsc-parser/core": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Add a button to read Next.js payload script tags

--- a/packages/core/src/components/ReadNextScriptTagsButton.stories.tsx
+++ b/packages/core/src/components/ReadNextScriptTagsButton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ReadNextScriptTagsButton } from "./ReadNextScriptTagsButton";
+
+const meta: Meta<typeof ReadNextScriptTagsButton> = {
+  component: ReadNextScriptTagsButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof ReadNextScriptTagsButton>;
+
+export const example: Story = {
+  name: "example",
+};

--- a/packages/core/src/components/ReadNextScriptTagsButton.tsx
+++ b/packages/core/src/components/ReadNextScriptTagsButton.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export function ReadNextScriptTagsButton({
+  onClickRead,
+}: {
+  onClickRead: () => void;
+}) {
+  return (
+    <button
+      className="rounded-md bg-slate-600 px-2 py-0.5 text-white dark:bg-slate-300 dark:text-black"
+      onClick={onClickRead}
+    >
+      Read Next.js script tag payload
+    </button>
+  );
+}

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -6,6 +6,7 @@ import { Logo } from "./components/Logo";
 import { RecordButton } from "./components/RecordButton";
 import { DebugCopyMessagesButton } from "./components/DebugCopyMessagesButton";
 import { ClearMessagesButton } from "./components/ClearMessagesButton";
+import { ReadNextScriptTagsButton } from "./components/ReadNextScriptTagsButton";
 import { PanelLayout } from "./components/PanelLayout";
 import {
   BottomPanel,
@@ -24,6 +25,7 @@ export {
   RecordButton,
   DebugCopyMessagesButton,
   ClearMessagesButton,
+  ReadNextScriptTagsButton,
   PanelLayout,
   BottomPanel,
   BottomPanelOpenButton,


### PR DESCRIPTION


Next.js stores the RSC payload in script tags. I've added a button to the panel in `@rsc-parse/embedded` to make #923 easier to debug.