### PR TITLE
Expose Viewer component

### DIFF
--- a/.changeset/tidy-dingos-deliver.md
+++ b/.changeset/tidy-dingos-deliver.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded-example": minor
+"@rsc-parser/core": minor
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/embedded": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Expose a `unstable_Viewer` component

--- a/packages/core/src/components/ViewerPayload.tsx
+++ b/packages/core/src/components/ViewerPayload.tsx
@@ -47,7 +47,7 @@ export function ViewerPayload({ defaultPayload }: { defaultPayload: string }) {
   );
 }
 
-function Viewer({ payload }: { payload: string }) {
+export function Viewer({ payload }: { payload: string }) {
   const messages = [
     {
       type: "RSC_CHUNK",

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,5 +1,8 @@
 import { RscChunkMessage } from "./types";
-import { ViewerPayload } from "./components/ViewerPayload";
+import {
+  ViewerPayload,
+  Viewer as unstable_Viewer,
+} from "./components/ViewerPayload";
 import { ViewerStreams } from "./components/ViewerStreams";
 import { ViewerStreamsEmptyState } from "./components/ViewerStreamsEmptyState";
 import { Logo } from "./components/Logo";
@@ -18,6 +21,7 @@ import { createFlightResponse as unstable_createFlightResponse } from "./createF
 export {
   type RscChunkMessage,
   ViewerPayload,
+  unstable_Viewer,
   ViewerStreams,
   ViewerStreamsEmptyState,
   Logo,


### PR DESCRIPTION
Exposing the `Viewer` component as `unstable_Viewer` so that it can be used in another project.