### PR TITLE
Only show links for which there are nodes in FlightResponseTabNetwork

### DIFF
--- a/.changeset/silly-cameras-matter.md
+++ b/.changeset/silly-cameras-matter.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/core": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/embedded": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Only show links for which there are nodes in FlightResponseTabNetwork

--- a/packages/core/src/components/FlightResponseTabNetwork.tsx
+++ b/packages/core/src/components/FlightResponseTabNetwork.tsx
@@ -79,7 +79,10 @@ function getLinks(chunks: Chunk[], id: string) {
 
   walk(id);
 
-  return links;
+  // Only return links for which there are nodes
+  return links.filter((link) =>
+    chunks.find((chunk) => chunk.id === link.target),
+  );
 }
 
 export function FlightResponseTabNetwork({


### PR DESCRIPTION
Fixes:
>  node not found: n