### PR TITLE
Capture request and response headers

### DIFF
--- a/packages/chrome-extension/public/manifest.json
+++ b/packages/chrome-extension/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RSC Devtools",
-  "version": "null",
+  "version": "0.4.2",
   "description": "React Server Components network visualizer",
   "content_security_policy": {
     "extension_pages": "script-src 'self' http://localhost:6020; object-src 'self'"

--- a/packages/core/src/components/PanelLayout.tsx
+++ b/packages/core/src/components/PanelLayout.tsx
@@ -10,7 +10,7 @@ export function PanelLayout({
   children: ReactNode;
 }) {
   return (
-    <div className="flex min-h-full flex-col">
+    <div className="flex min-h-full flex-col text-sm">
       <div className="sticky top-0 z-30 flex flex-row justify-between bg-slate-100 p-3 dark:bg-slate-900">
         <div className="flex flex-row items-center gap-4">{header}</div>
         {closeButton}

--- a/packages/core/src/components/ViewerPayload.tsx
+++ b/packages/core/src/components/ViewerPayload.tsx
@@ -55,6 +55,8 @@ export function Viewer({ payload }: { payload: string }) {
       data: {
         fetchUrl: "https://example.com",
         fetchMethod: "GET",
+        fetchRequestHeaders: null,
+        fetchResponseHeaders: null,
         fetchStartTime: 0,
         chunkStartTime: 0,
         chunkEndTime: 0,

--- a/packages/core/src/components/ViewerStreams.tsx
+++ b/packages/core/src/components/ViewerStreams.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { TabList, Tab, TabPanel, TabProvider } from "@ariakit/react";
 import { createFlightResponse } from "../createFlightResponse";
 import { RscChunkMessage } from "../types";
 import { FlightResponse } from "./FlightResponse";
@@ -40,11 +41,79 @@ export function ViewerStreams({ messages }: { messages: RscChunkMessage[] }) {
           {!pathTabs.currentTab ? (
             <span>Please select a url</span>
           ) : (
-            <FlightResponse flightResponse={flightResponse} />
+            <TabProvider>
+              <TabList
+                aria-label="Render modes"
+                className="flex flex-row gap-2"
+              >
+                <Tab
+                  id="flightResponse"
+                  className="rounded-md px-2 py-0.5 aria-selected:bg-slate-300 dark:aria-selected:text-black"
+                >
+                  Flight response
+                </Tab>
+                <Tab
+                  id="headers"
+                  className="rounded-md px-2 py-0.5 aria-selected:bg-slate-300 dark:aria-selected:text-black"
+                >
+                  Headers
+                </Tab>
+              </TabList>
+
+              <TabPanel tabId="flightResponse">
+                <FlightResponse flightResponse={flightResponse} />
+              </TabPanel>
+
+              <TabPanel tabId="headers" className="flex flex-col gap-4">
+                <section className="flex flex-col gap-1">
+                  <p>Request headers</p>
+                  {messagesForCurrentTab[0] &&
+                  messagesForCurrentTab[0].data.fetchResponseHeaders ? (
+                    <HeadersTable
+                      headers={
+                        messagesForCurrentTab[0].data.fetchResponseHeaders
+                      }
+                    />
+                  ) : (
+                    "No response headers"
+                  )}
+                </section>
+                <section className="flex flex-col gap-1">
+                  <p>Response headers</p>
+                  {messagesForCurrentTab[0] &&
+                  messagesForCurrentTab[0].data.fetchRequestHeaders ? (
+                    <HeadersTable
+                      headers={
+                        messagesForCurrentTab[0].data.fetchRequestHeaders
+                      }
+                    />
+                  ) : (
+                    "No request headers"
+                  )}
+                </section>
+              </TabPanel>
+            </TabProvider>
           )}
         </FlightResponseSelector>
       </EndTimeContext.Provider>
     </div>
+  );
+}
+
+function HeadersTable({ headers }: { headers: Record<string, string> }) {
+  return (
+    <table className="w-full max-w-4xl table-fixed border-collapse border border-slate-500">
+      <tbody>
+        {Object.entries(headers).map(([key, value]) => (
+          <tr key={key}>
+            <td className="border border-slate-500 px-1.5 py-0.5">{key}</td>
+            <td className="whitespace-pre-wrap break-all border border-slate-500 px-1.5 py-0.5">
+              {value}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/packages/core/src/example-data/alvar-dev.ts
+++ b/packages/core/src/example-data/alvar-dev.ts
@@ -6,6 +6,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://www.alvar.dev/blog?_rsc=1sxgj",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526298,
       chunkValue: [
         50, 58, 73, 91, 50, 53, 50, 53, 48, 44, 91, 34, 53, 50, 53, 48, 34, 44,
@@ -30,6 +32,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://www.alvar.dev/blog?_rsc=1sxgj",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526298,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -448,6 +452,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://www.alvar.dev/blog?_rsc=1sxgj",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526298,
       chunkValue: [
         52, 58, 91, 34, 36, 34, 44, 34, 100, 105, 118, 34, 44, 110, 117, 108,
@@ -740,6 +746,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/thoughts-on-photography-tools?_rsc=18e5w",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526548,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -768,6 +776,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/always-add-name-to-type-radio?_rsc=18e5w",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526581,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -796,6 +806,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/tailwindcss-with-next-font?_rsc=18e5w",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526547,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -824,6 +836,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=18e5w",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526547,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -853,6 +867,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/skeleton-loading-with-suspense-in-next-js-13?_rsc=18e5w",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448526547,
       chunkValue: [
         48, 58, 91, 34, 87, 89, 106, 69, 45, 79, 83, 72, 85, 105, 48, 45, 87,
@@ -882,6 +898,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448528308,
       chunkValue: [
         51, 58, 73, 91, 53, 54, 49, 51, 44, 91, 93, 44, 34, 34, 93, 10, 53, 58,
@@ -1206,6 +1224,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448528308,
       chunkValue: [
         56, 58, 73, 91, 56, 49, 57, 55, 50, 44, 91, 34, 53, 50, 53, 48, 34, 44,
@@ -3674,6 +3694,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448528308,
       chunkValue: [
         49, 50, 58, 34, 36, 76, 49, 55, 34, 10, 49, 51, 58, 34, 36, 76, 49, 56,
@@ -3691,6 +3713,8 @@ export const alvarDevExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://www.alvar.dev/blog/creating-devtools-for-react-server-components?_rsc=1yujw",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706448528308,
       chunkValue: [
         49, 55, 58, 91, 34, 36, 34, 44, 34, 100, 105, 118, 34, 44, 110, 117,

--- a/packages/core/src/example-data/gh-fredkiss-dev.ts
+++ b/packages/core/src/example-data/gh-fredkiss-dev.ts
@@ -6,6 +6,8 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=kvatu",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706451203109,
       chunkValue: [
         55, 58, 73, 91, 50, 48, 55, 48, 44, 91, 93, 44, 34, 34, 93, 10, 97, 58,
@@ -35,6 +37,8 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=kvatu",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706451203109,
       chunkValue: [
         48, 58, 91, 34, 103, 90, 86, 119, 81, 120, 87, 56, 117, 51, 50, 115, 71,
@@ -453,6 +457,8 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=kvatu",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706451203109,
       chunkValue: [
         50, 58, 91, 34, 36, 34, 44, 34, 110, 97, 118, 34, 44, 110, 117, 108,
@@ -641,6 +647,8 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=1326h",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706451203252,
       chunkValue: [
         51, 58, 73, 91, 50, 48, 55, 48, 44, 91, 93, 44, 34, 34, 93, 10, 54, 58,
@@ -1037,6 +1045,8 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=1326h",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706451203252,
       chunkValue: [
         55, 58, 91, 91, 34, 36, 34, 44, 34, 109, 101, 116, 97, 34, 44, 34, 48,
@@ -1263,6 +1273,8 @@ export const ghFredkissDevExampleData: RscChunkMessage[] = [
     data: {
       fetchUrl: "https://gh.fredkiss.dev/Fredkiss3/gh-next/actions?_rsc=1ho2t",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706451203373,
       chunkValue: [
         57, 58, 73, 91, 57, 57, 49, 52, 44, 91, 34, 57, 57, 49, 52, 34, 44, 34,

--- a/packages/core/src/example-data/nextjs-org.ts
+++ b/packages/core/src/example-data/nextjs-org.ts
@@ -7,6 +7,8 @@ export const nextjsOrgExampleData: RscChunkMessage[] = [
       fetchUrl:
         "https://nextjs.org/docs/app/building-your-application/routing?_rsc=2xhb5",
       fetchMethod: "GET",
+      fetchRequestHeaders: null,
+      fetchResponseHeaders: null,
       fetchStartTime: 1706452689281,
       chunkValue: [
         50, 58, 73, 91, 49, 49, 49, 50, 57, 44, 91, 34, 53, 49, 53, 51, 34, 44,

--- a/packages/core/src/fetchPatcher.ts
+++ b/packages/core/src/fetchPatcher.ts
@@ -127,7 +127,6 @@ export function fetchPatcher({
           fetchUrl: convertLocalUrlToAbsolute(url),
           fetchMethod: requestMethod,
           fetchRequestHeaders: requestHeaders,
-          fetchResponseStatus: response.status,
           fetchResponseHeaders: responseHeaders,
           fetchStartTime,
           chunkValue: Array.from(value),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,7 +6,6 @@ export type RscChunkMessage = {
     // TODO: Rename to fetchRequestMethod
     fetchMethod: "GET" | "POST";
     fetchRequestHeaders: Record<string, string> | null;
-    fetchResponseStatus: number | null;
     fetchResponseHeaders: Record<string, string> | null;
     fetchStartTime: number;
     chunkValue: number[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,7 +3,11 @@ export type RscChunkMessage = {
   tabId: number;
   data: {
     fetchUrl: string;
+    // TODO: Rename to fetchRequestMethod
     fetchMethod: "GET" | "POST";
+    fetchRequestHeaders: Record<string, string> | null;
+    fetchResponseStatus: number | null;
+    fetchResponseHeaders: Record<string, string> | null;
     fetchStartTime: number;
     chunkValue: number[];
     chunkStartTime: number;


### PR DESCRIPTION
The fetch patcher will now pick up the request and response headers to be presented in the UI.

As requested by @juliusmarminge in a [Tweet](https://x.com/jullerino/status/1798979390057185583)

![image](https://github.com/alvarlagerlof/rsc-parser/assets/14835120/e3a3b951-ce2b-48b8-a9f8-2137135bcb6f)
