### PR TITLE
Ensure that the current ViewerStreams tab always is re-rendered when switching tabs

### DIFF
--- a/packages/core/src/components/ViewerStreams.tsx
+++ b/packages/core/src/components/ViewerStreams.tsx
@@ -41,7 +41,7 @@ export function ViewerStreams({ messages }: { messages: RscChunkMessage[] }) {
           {!pathTabs.currentTab ? (
             <span>Please select a url</span>
           ) : (
-            <TabProvider>
+            <TabProvider key={pathTabs.currentTab}>
               <TabList
                 aria-label="Render modes"
                 className="flex flex-row gap-2"


### PR DESCRIPTION


Was seeing weird behaviour with duplicated tabs.