### PR TITLE
Fix versioning script

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,12 @@
   "commit": false,
   "fixed": [],
   "linked": [
-    ["@rsc-parser/chrome-extension", "@rsc-parser/core", "@rsc-parser/website"]
+    [
+      "@rsc-parser/chrome-extension",
+      "@rsc-parser/core",
+      "@rsc-parser/website",
+      "@rsc-parser/embedded"
+    ]
   ],
   "access": "public",
   "baseBranch": "main",

--- a/apply-version.sh
+++ b/apply-version.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
 set -e
 
-# Step 1: Get the changeset status
-yarn changeset status --since origin/main --output version.json
-
-# Step 2: Extract newVersion from version.json
-new_version=$(jq -r '.releases[0].newVersion' version.json)
+# Step 1: Extract newVersion from ./packages/core/package.json
+new_version=$(jq -r '.version' ./packages/core/package.json)
 echo "Found new version: $new_version"
 
-# Step 3: Update the version in manifest.json
+# Step 2: Update the version in manifest.json
 jq --arg version "$new_version" '.version = $version' packages/chrome-extension/public/manifest.json > tmp.json && mv tmp.json packages/chrome-extension/public/manifest.json
 echo "Applied new version: $_new_version"
 
-# Step 4: Clean up
+# Step 3: Clean up
 yarn prettier -w packages/chrome-extension/public/manifest.json
-rm version.json

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "turbo run format",
     "ci": "turbo run ci",
     "dev": "turbo run dev",
-    "version": "bash ./apply-version.sh && changeset version",
+    "version": "changeset version bash ./apply-version.sh",
     "release": "changeset publish",
     "knip": "knip"
   },


### PR DESCRIPTION
It seems that `yarn changeset status --since origin/main --output version.json` no longer works as before (see https://github.com/changesets/changesets/issues/700)

It's needed to update the manifest file for the chrome extension. Instead we can apply the version to all package.json files and read it from one of them.