### PR TITLE
Ensure that `react` and `react-dom` are externalized

### DIFF
--- a/.changeset/mighty-badgers-thank.md
+++ b/.changeset/mighty-badgers-thank.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded": patch
+"@rsc-parser/core": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Ensure that `react` and `react-dom` are externalized

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,26 @@
     "package.json",
     "dist"
   ],
+  "type": "module",
+  "style": "./dist/style.css",
+  "exports": {
+    ".": {
+      "import": "./dist/js/main.js",
+      "types": "./dist/js/src/main.d.ts"
+    },
+    "./style.css": {
+      "import": "./dist/style.css"
+    },
+    "./fetchPatcher": {
+      "import": "./dist/js/fetchPatcher.js",
+      "types": "./dist/js/src/fetchPatcher.d.ts"
+    }
+  },
+  "dependencies": {
+    "d3": "7.9.0",
+    "react-error-boundary": "4.0.13",
+    "react-resizable-panels": "2.0.19"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.4.0",
@@ -41,8 +61,6 @@
     "jest-environment-jsdom": "29.7.0",
     "postcss": "8.4.38",
     "prettier": "3.3.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
     "tailwindcss": "3.4.4",
     "ts-jest": "29.1.4",
     "typescript": "5.4.5",
@@ -50,24 +68,8 @@
     "vite": "5.2.13",
     "vite-plugin-dts": "3.9.1"
   },
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": "./dist/js/main.js",
-      "types": "./dist/js/src/main.d.ts"
-    },
-    "./style.css": {
-      "import": "./dist/style.css"
-    },
-    "./fetchPatcher": {
-      "import": "./dist/js/fetchPatcher.js",
-      "types": "./dist/js/src/fetchPatcher.d.ts"
-    }
-  },
-  "style": "./dist/style.css",
-  "dependencies": {
-    "d3": "7.9.0",
-    "react-error-boundary": "4.0.13",
-    "react-resizable-panels": "2.0.19"
+  "peerDependencies": {
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   }
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       },
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ["react"],
+      external: ["react", "react-dom"],
       output: {
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,

--- a/packages/embedded/package.json
+++ b/packages/embedded/package.json
@@ -12,6 +12,10 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
+  "files": [
+    "package.json",
+    "dist"
+  ],
   "types": "./dist/js/RscDevtoolsPanel.d.ts",
   "exports": {
     ".": {
@@ -19,21 +23,11 @@
     },
     "./style.css": "./dist/style.css"
   },
-  "files": [
-    "package.json",
-    "dist"
-  ],
-  "dependencies": {
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
-  },
   "devDependencies": {
     "@eslint/js": "9.4.0",
     "@rsc-parser/core": "workspace:^",
     "@vitejs/plugin-react": "4.3.0",
     "eslint": "9.4.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
     "rollup-plugin-preserve-directives": "0.4.0",
     "typescript": "5.4.5",
     "vite": "5.2.13",

--- a/packages/embedded/vite.config.ts
+++ b/packages/embedded/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ["react"],
+      external: ["react", "react-dom"],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps

--- a/yarn.lock
+++ b/yarn.lock
@@ -3901,8 +3901,6 @@ __metadata:
     jest-environment-jsdom: "npm:29.7.0"
     postcss: "npm:8.4.38"
     prettier: "npm:3.3.1"
-    react: "npm:18.3.1"
-    react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.13"
     react-resizable-panels: "npm:2.0.19"
     tailwindcss: "npm:3.4.4"
@@ -3911,6 +3909,9 @@ __metadata:
     typescript-eslint: "npm:7.12.0"
     vite: "npm:5.2.13"
     vite-plugin-dts: "npm:3.9.1"
+  peerDependencies:
+    react: 18.3.1
+    react-dom: 18.3.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,8 +3946,6 @@ __metadata:
     "@rsc-parser/core": "workspace:^"
     "@vitejs/plugin-react": "npm:4.3.0"
     eslint: "npm:9.4.0"
-    react: "npm:18.3.1"
-    react-dom: "npm:18.3.1"
     rollup-plugin-preserve-directives: "npm:0.4.0"
     typescript: "npm:5.4.5"
     vite: "npm:5.2.13"


### PR DESCRIPTION
Had some trouble at work with `@rsc-parser/embedded` that may have come from there potentially being two copies `react-dom`.