### PR TITLE
Sync the version @rsc-parser/embedded-example with the other packages

### DIFF
--- a/.changeset/nice-ducks-give.md
+++ b/.changeset/nice-ducks-give.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/core": patch
+"@rsc-parser/embedded": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Sync the version @rsc-parser/embedded-example with the other packages

--- a/examples/embedded-example/package.json
+++ b/examples/embedded-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsc-parser/embedded-example",
   "packageManager": "yarn@4.2.2",
-  "version": "0.18.2",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The version was `0.18.2` but it should be `0.4.2`