### PR TITLE
Decrease the minimum panel sizes in `FlightResponseSelector`

### DIFF
--- a/.changeset/plenty-pears-wonder.md
+++ b/.changeset/plenty-pears-wonder.md
@@ -1,0 +1,10 @@
+---
+"@rsc-parser/core": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/embedded": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Decrease the minimum panel sizes in `FlightResponseSelector`

--- a/packages/core/src/components/FlightResponseSelector.tsx
+++ b/packages/core/src/components/FlightResponseSelector.tsx
@@ -83,7 +83,7 @@ export function FlightResponseSelector({
 }: ReturnType<typeof useFlightResponseSelector> & { children: ReactNode }) {
   return (
     <PanelGroup direction="horizontal">
-      <Panel id="sidebar" minSize={35} order={1} defaultSize={35}>
+      <Panel id="sidebar" minSize={20} order={1} defaultSize={35}>
         <TabList store={tabStore} className="flex flex-col gap-1 pr-3">
           {tabs.map((tab) => {
             const fetchMethod = messages.find(
@@ -126,7 +126,7 @@ export function FlightResponseSelector({
 
       <PanelResizeHandle className="w-1 rounded bg-slate-200 dark:bg-slate-800" />
 
-      <Panel order={2} minSize={30} className="">
+      <Panel order={2} minSize={20} className="">
         <TabPanel
           store={tabStore}
           tabId={currentTab}


### PR DESCRIPTION
For large screen widths, the sidebar showing requests is always very big.