### PR TITLE
Improve Headers tab design and add general information

### DIFF
--- a/.changeset/happy-plants-fly.md
+++ b/.changeset/happy-plants-fly.md
@@ -1,0 +1,11 @@
+---
+"@rsc-parser/core": minor
+"@rsc-parser/embedded-example": minor
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/embedded": minor
+"@rsc-parser/react-client": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Improve Headers tab design and add general information

--- a/packages/core/src/components/EndTimeContext.tsx
+++ b/packages/core/src/components/EndTimeContext.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   ReactNode,
   createContext,

--- a/packages/core/src/components/RequestDetail.tsx
+++ b/packages/core/src/components/RequestDetail.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { TabList, Tab, TabPanel, TabProvider } from "@ariakit/react";
 import { RscEvent, isRscRequestEvent, isRscResponseEvent } from "../events";
 import { GenericErrorBoundaryFallback } from "./GenericErrorBoundaryFallback";

--- a/packages/core/src/components/RequestDetailTabHeaders.tsx
+++ b/packages/core/src/components/RequestDetailTabHeaders.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { eventsFilterByMaxTimestamp } from "../eventArrayHelpers";
 import { RscEvent, isRscRequestEvent, isRscResponseEvent } from "../events";
 import { useEndTime } from "./EndTimeContext";
@@ -11,40 +12,60 @@ export function RequestDetailTabHeaders({ events }: { events: RscEvent[] }) {
   const responseEvent = timeFilteredEvents.filter(isRscResponseEvent)[0];
 
   return (
-    <div className="flex flex-col gap-4">
-      <section className="flex flex-col gap-1">
-        <p>Request headers</p>
-        {requestEvent ? (
-          <HeadersTable headers={requestEvent.data.headers} />
-        ) : (
-          "No response headers"
-        )}
-      </section>
-      <section className="flex flex-col gap-1">
-        <p>Response headers</p>
-        {responseEvent ? (
-          <HeadersTable headers={responseEvent.data.headers} />
-        ) : (
-          "No request headers"
-        )}
-      </section>
+    <div className="flex flex-col gap-6">
+      {requestEvent ? (
+        <Table
+          header="General Information"
+          data={{
+            "Request URL": requestEvent.data.url,
+            "Request Method": requestEvent.data.method,
+            ...(responseEvent
+              ? { "Status Code": responseEvent.data.status }
+              : {}),
+          }}
+        />
+      ) : (
+        "No general information"
+      )}
+
+      {requestEvent ? (
+        <Table header="Request Headers" data={requestEvent.data.headers} />
+      ) : (
+        "No response headers"
+      )}
+
+      {responseEvent ? (
+        <Table header="Response Headers" data={responseEvent.data.headers} />
+      ) : (
+        "No request headers"
+      )}
     </div>
   );
 }
 
-function HeadersTable({ headers }: { headers: Record<string, string> }) {
+function Table({
+  header,
+  data,
+}: {
+  header: string;
+  data: Record<string, string | number>;
+}) {
   return (
-    <table className="w-full max-w-4xl table-fixed border-collapse border border-slate-500 dark:text-white">
-      <tbody>
-        {Object.entries(headers).map(([key, value]) => (
-          <tr key={key}>
-            <td className="border border-slate-500 px-1.5 py-0.5">{key}</td>
-            <td className="whitespace-pre-wrap break-all border border-slate-500 px-1.5 py-0.5">
-              {value}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <details open className="max-w-2xl">
+      <summary className="font-semibold">{header}</summary>
+      <table className="ml-3 mt-1 w-full table-auto dark:text-white">
+        <tbody>
+          {Object.entries(data).map(([key, value]) => (
+            <tr
+              key={key}
+              className="block border-y border-slate-300 py-1 first:border-t-0 last:border-b-0 dark:border-slate-600"
+            >
+              <td className="min-w-52 border-slate-500">{key}</td>
+              <td className="whitespace-pre-wrap break-all">{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </details>
   );
 }


### PR DESCRIPTION
Made the design prettier and added a "General Information" section that shows the URL, method, and status code.

# Before
<img width="838" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/d1055270-bd8d-4e23-a23a-d79cb30dcb9f">



# After
<img width="668" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/06e9a5e3-e9a3-4b6a-8506-66be8e64e185">
