### PR TITLE
Add text on top of links in `RequestDetailTabNetwork`

### DIFF
--- a/.changeset/quick-donkeys-dance.md
+++ b/.changeset/quick-donkeys-dance.md
@@ -1,0 +1,11 @@
+---
+"@rsc-parser/core": minor
+"@rsc-parser/embedded-example": minor
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/embedded": minor
+"@rsc-parser/react-client": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Add text on top of links in `RequestDetailTabNetwork`


### PR DESCRIPTION
In the "Network" tab, there is now text on top of the links. It's showing the reference types and the time diff between the chunks. Needs more polish later.