### PR TITLE
Fix `contentScript.ts` bundling to avoid ESM imports

### DIFF
--- a/.changeset/fifty-lizards-hear.md
+++ b/.changeset/fifty-lizards-hear.md
@@ -1,0 +1,11 @@
+---
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/core": patch
+"@rsc-parser/embedded": patch
+"@rsc-parser/react-client": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Fix `contentScript.ts` bundling to avoid ESM imports

--- a/packages/chrome-extension/src/assets/contentScript.ts
+++ b/packages/chrome-extension/src/assets/contentScript.ts
@@ -1,8 +1,54 @@
-import { RscEvent, isRscEvent } from "@rsc-parser/core/events";
 import {
-  StopRecordingEvent,
-  isStartRecordingEvent,
+  type RscEvent,
+  type StopRecordingEvent,
 } from "@rsc-parser/core/events";
+// import { RscEvent, isRscEvent } from "@rsc-parser/core/events";
+// import {
+//   StopRecordingEvent,
+//   isStartRecordingEvent,
+// } from "@rsc-parser/core/events";
+
+// TODO: Find a way that these can be imported that makes them bundled
+// into the output file without using ESM imports
+function isStartRecordingEvent(event: unknown) {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "START_RECORDING"
+  );
+}
+function isRscRequestEvent(event: unknown) {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "RSC_REQUEST"
+  );
+}
+function isRscResponseEvent(event: unknown) {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "RSC_RESPONSE"
+  );
+}
+function isRscChunkEvent(event: unknown) {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "RSC_CHUNK"
+  );
+}
+function isRscEvent(event: unknown) {
+  return (
+    isRscRequestEvent(event) ||
+    isRscResponseEvent(event) ||
+    isRscChunkEvent(event)
+  );
+}
 
 /**
  * injectScript - Inject internal script to available access to the `window`


### PR DESCRIPTION
The output `contentScript.ts` cannot have any ESM imports, so some code duplication is needed to hot-fix this.