### PR TITLE
Add flex wrapping to the tabs in `RequestDetail`

### DIFF
--- a/.changeset/cyan-snails-cough.md
+++ b/.changeset/cyan-snails-cough.md
@@ -1,0 +1,11 @@
+---
+"@rsc-parser/core": patch
+"@rsc-parser/embedded-example": patch
+"@rsc-parser/chrome-extension": patch
+"@rsc-parser/embedded": patch
+"@rsc-parser/react-client": patch
+"@rsc-parser/storybook": patch
+"@rsc-parser/website": patch
+---
+
+Add flex wrapping to the tabs in `RequestDetail`

--- a/packages/core/src/components/RequestDetail.tsx
+++ b/packages/core/src/components/RequestDetail.tsx
@@ -18,7 +18,10 @@ export function RequestDetail({ events }: { events: RscEvent[] }) {
   return (
     <TabProvider store={tabStore}>
       <div className="flex w-full flex-col gap-4">
-        <TabList aria-label="Render modes" className="flex flex-row gap-2">
+        <TabList
+          aria-label="Render modes"
+          className="flex flex-row flex-wrap gap-2"
+        >
           <Tab
             id="headers"
             className="rounded-md bg-slate-200 px-2 py-0.5 aria-disabled:opacity-50 aria-selected:bg-slate-300 dark:bg-slate-700 dark:aria-selected:text-black"


### PR DESCRIPTION
Ensures that they don't look bad when the screen width isn't big.

# Before
<img width="459" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/6ab5f735-9634-44da-aa51-cceb499f01f6">


# After
<img width="459" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/902513de-215b-4bba-bb24-ab3a647058a2">
