### PR TITLE
Make the "Headers" tab table column 1 min-size smaller, and make the `BottomPanel` default size larger

### DIFF
--- a/.changeset/angry-cameras-sleep.md
+++ b/.changeset/angry-cameras-sleep.md
@@ -1,0 +1,11 @@
+---
+"@rsc-parser/core": minor
+"@rsc-parser/embedded-example": minor
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/embedded": minor
+"@rsc-parser/react-client": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Make the "Headers" tab table column 1 min-size smaller, and make the `BottomPanel` default size larger

--- a/packages/core/src/components/BottomPanel.tsx
+++ b/packages/core/src/components/BottomPanel.tsx
@@ -32,7 +32,7 @@ export function BottomPanel({
             setIsDragging(isDragging);
           }}
         />
-        <Panel order={2} maxSize={75} minSize={20} defaultSize={30}>
+        <Panel order={2} maxSize={75} minSize={20} defaultSize={45}>
           <div className="pointer-events-auto size-full overflow-y-auto bg-slate-100 scrollbar-gutter-stable dark:bg-slate-900">
             {children}
           </div>

--- a/packages/core/src/components/RequestDetailTabHeaders.tsx
+++ b/packages/core/src/components/RequestDetailTabHeaders.tsx
@@ -65,7 +65,7 @@ function Table({
               key={key}
               className="block border-y border-slate-300 py-1 first:border-t-0 last:border-b-0 dark:border-slate-600"
             >
-              <td className="min-w-52 border-slate-500">{key}</td>
+              <td className="min-w-32 border-slate-500">{key}</td>
               <td className="whitespace-pre-wrap break-all">{value}</td>
             </tr>
           ))}


### PR DESCRIPTION


For smaller screen widths, things got crammed.