### PR TITLE
Redesign `RequestTab` again

### DIFF
--- a/.changeset/metal-kings-sneeze.md
+++ b/.changeset/metal-kings-sneeze.md
@@ -1,0 +1,11 @@
+---
+"@rsc-parser/core": minor
+"@rsc-parser/embedded-example": minor
+"@rsc-parser/chrome-extension": minor
+"@rsc-parser/embedded": minor
+"@rsc-parser/react-client": minor
+"@rsc-parser/storybook": minor
+"@rsc-parser/website": minor
+---
+
+Redesign `RequestTab` again

--- a/packages/core/src/components/ViewerStreams.tsx
+++ b/packages/core/src/components/ViewerStreams.tsx
@@ -97,16 +97,16 @@ function RequestTab({ events }: { events: RscEvent[] }) {
   const { status } = responseEvent?.data ?? {};
 
   return (
-    <div className="flex w-full flex-row items-center gap-2 rounded-md border-none px-1.5 py-0.5 text-left group-aria-selected:bg-slate-200 dark:group-aria-selected:bg-slate-700">
+    <div className="flex w-full flex-row items-center gap-2 rounded-md border-none px-1.5 py-1 text-left group-aria-selected:bg-slate-200 dark:group-aria-selected:bg-slate-700">
       <div
-        className="size-[14px] min-h-[14px] min-w-[14px] rounded-full"
+        className="h-5 min-h-5 w-1 min-w-1 rounded-md"
         style={{
           background: getColorForFetch(events[0].data.requestId),
         }}
       ></div>
-      <div className="flex flex-col gap-0.5">
-        <span className="inline-block w-[10ch] text-slate-500 dark:text-slate-400">
-          {method} ({status ?? "..."})
+      <div className="flex flex-row gap-1">
+        <span className="inline-block min-w-[4ch] font-medium text-slate-500 dark:text-slate-400">
+          {method} {status !== 200 && status !== undefined ? `(${status})` : ""}
         </span>
         <div>
           <span className="text-slate-900 dark:text-white">


### PR DESCRIPTION
Trying to get it to in a small width better

# Before
<img width="568" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/8ad327b4-122a-4a9d-a13d-b463f1c4a783">

# After
<img width="581" alt="image" src="https://github.com/alvarlagerlof/rsc-parser/assets/14835120/60fc7738-9151-4b59-a9a5-e62ef99dc155">

