### PR TITLE
Make it possible to read Next.js script tags containing RSC payload data from the chrome extension

### DIFF
--- a/.changeset/nervous-turkeys-explode.md
+++ b/.changeset/nervous-turkeys-explode.md
@@ -1,0 +1,11 @@
+---
+'@rsc-parser/chrome-extension': minor
+'@rsc-parser/embedded': minor
+'@rsc-parser/core': minor
+'@rsc-parser/embedded-example': minor
+'@rsc-parser/react-client': minor
+'@rsc-parser/storybook': minor
+'@rsc-parser/website': minor
+---
+
+Make it possible to read Next.js script tags from the Chrome extension

--- a/packages/chrome-extension/public/manifest.json
+++ b/packages/chrome-extension/public/manifest.json
@@ -18,6 +18,10 @@
     {
       "resources": ["assets/fetchPatcherInjector.js"],
       "matches": ["http://*/*", "https://*/*"]
+    },
+    {
+      "resources": ["assets/readNextJsScriptTagsInjector.js"],
+      "matches": ["http://*/*", "https://*/*"]
     }
   ]
 }

--- a/packages/chrome-extension/src/RscDevtoolsExtension.tsx
+++ b/packages/chrome-extension/src/RscDevtoolsExtension.tsx
@@ -23,10 +23,17 @@ import {
   isRscChunkEvent,
   isRscEvent,
   isStopRecordingEvent,
+  ReadNextJsScriptTagsEvent,
 } from '@rsc-parser/core/events';
 
 export function RscDevtoolsExtension() {
-  const { isRecording, startRecording, events, clearEvents } = useRscEvents();
+  const {
+    isRecording,
+    startRecording,
+    events,
+    clearEvents,
+    triggerReadNextJsScriptTags,
+  } = useRscEvents();
 
   return (
     <PanelLayout
@@ -54,6 +61,13 @@ export function RscDevtoolsExtension() {
                     Copy events to clipboard
                   </button>
                 ) : null}
+                <button
+                  onClick={() => {
+                    triggerReadNextJsScriptTags();
+                  }}
+                >
+                  Read Next.js script tag payload
+                </button>
               </>
             }
           />
@@ -142,11 +156,22 @@ function useRscEvents() {
     setEvents([]);
   }, []);
 
+  const triggerReadNextJsScriptTags = useCallback(() => {
+    setIsRecording(true);
+    chrome.tabs.sendMessage(chrome.devtools.inspectedWindow.tabId, {
+      type: 'READ_NEXT_JS_SCRIPT_TAGS',
+      data: {
+        tabId: tabId,
+      },
+    } satisfies ReadNextJsScriptTagsEvent);
+  }, []);
+
   return {
     isRecording,
     startRecording,
     events,
     clearEvents,
+    triggerReadNextJsScriptTags,
   };
 }
 

--- a/packages/chrome-extension/src/assets/readNextJsScriptTagsInjector.ts
+++ b/packages/chrome-extension/src/assets/readNextJsScriptTagsInjector.ts
@@ -1,0 +1,11 @@
+import { readNextJsScriptTags } from '@rsc-parser/core/readNextJsScriptTags';
+
+(() => {
+  const events = readNextJsScriptTags();
+
+  if (events) {
+    for (const event of events) {
+      window.postMessage(event, '*');
+    }
+  }
+})();

--- a/packages/chrome-extension/vite.config.ts
+++ b/packages/chrome-extension/vite.config.ts
@@ -46,6 +46,10 @@ export default defineConfig(({ mode }) => {
               __dirname,
               'src/assets/fetchPatcherInjector.ts',
             ),
+            readNextJsScriptTagsInjector: resolve(
+              __dirname,
+              'src/assets/readNextJsScriptTagsInjector.ts',
+            ),
             contentScript: resolve(__dirname, 'src/assets/contentScript.ts'),
             devtoolsPage: resolve(__dirname, 'src/assets/devtoolsPage.ts'),
           },
@@ -75,6 +79,10 @@ export default defineConfig(({ mode }) => {
           fetchPatcherInjector: resolve(
             __dirname,
             'src/assets/fetchPatcherInjector.ts',
+          ),
+          readNextJsScriptTagsInjector: resolve(
+            __dirname,
+            'src/assets/readNextJsScriptTagsInjector.ts',
           ),
           contentScript: resolve(__dirname, 'src/assets/contentScript.ts'),
           devtoolsPage: resolve(__dirname, 'src/assets/devtoolsPage.ts'),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,10 @@
       "import": "./dist/fetchPatcher.js",
       "types": "./dist/fetchPatcher.d.ts"
     },
+    "./readNextJsScriptTags": {
+      "import": "./dist/readNextJsScriptTags.js",
+      "types": "./dist/readNextJsScriptTags.d.ts"
+    },
     "./events": {
       "import": "./dist/events.js",
       "types": "./dist/events.d.ts"

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -34,6 +34,24 @@ export function isStopRecordingEvent(
   );
 }
 
+export type ReadNextJsScriptTagsEvent = {
+  type: 'READ_NEXT_JS_SCRIPT_TAGS';
+  data: {
+    tabId: number;
+  };
+};
+
+export function isReadNextJsScriptTagsEvent(
+  event: unknown,
+): event is ReadNextJsScriptTagsEvent {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    'type' in event &&
+    event.type === 'READ_NEXT_JS_SCRIPT_TAGS'
+  );
+}
+
 type RscEventSharedData = {
   data: {
     tabId: number;
@@ -109,6 +127,7 @@ export function isEvent(event: unknown): event is Event {
   return (
     isStartRecordingEvent(event) ||
     isStopRecordingEvent(event) ||
-    isRscEvent(event)
+    isRscEvent(event) ||
+    isReadNextJsScriptTagsEvent(event)
   );
 }

--- a/packages/core/src/readNextJsScriptTags.ts
+++ b/packages/core/src/readNextJsScriptTags.ts
@@ -1,0 +1,51 @@
+import { RscEvent } from './events';
+
+export function readNextJsScriptTags(): RscEvent[] | undefined {
+  try {
+    // @ts-expect-error This is a hack
+    const payload = self.__next_f.map((f) => f?.[1]).join('');
+
+    const requestId = String(Date.now() + Math.random()); // TODO: Use a better random number generator or uuid
+
+    const events = [
+      {
+        type: 'RSC_REQUEST',
+        data: {
+          requestId: requestId,
+          tabId: 0,
+          timestamp: Date.now(),
+          url: window.location.href,
+          method: 'GET',
+          headers: {},
+        },
+      },
+      {
+        type: 'RSC_RESPONSE',
+        data: {
+          requestId: requestId,
+          tabId: 0,
+          timestamp: Date.now(),
+          status: 200,
+          headers: {},
+        },
+      },
+      {
+        type: 'RSC_CHUNK',
+        data: {
+          requestId: requestId,
+          tabId: 0,
+          timestamp: Date.now(),
+          chunkValue: Array.from(new TextEncoder().encode(payload)),
+        },
+      },
+    ] satisfies RscEvent[];
+
+    return events;
+  } catch (error) {
+    console.error(
+      new Error('Error parsing Next.js payload', {
+        cause: error,
+      }),
+    );
+  }
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       entry: {
         main: resolve(__dirname, 'src/main.ts'),
         fetchPatcher: resolve(__dirname, 'src/fetchPatcher.ts'),
+        readNextJsScriptTags: resolve(__dirname, 'src/readNextJsScriptTags.ts'),
         events: resolve(__dirname, 'src/events.ts'),
       },
       formats: ['es'],


### PR DESCRIPTION

The Next.js server will add a bunch of script tags to the body containing RSC payload data.

The @rsc-parser/embedded package can already read this by making a pretend request. With this change, @rsc-parser/chrome-extension can read it too.

https://github.com/user-attachments/assets/a84f45b9-bd88-496a-ba9f-990e2d340efc

