### PR TITLE
Add one error boundary per tab panel in RequestDetail

### DIFF
--- a/.changeset/curly-apples-heal.md
+++ b/.changeset/curly-apples-heal.md
@@ -1,0 +1,11 @@
+---
+'@rsc-parser/core': minor
+'@rsc-parser/embedded-example': minor
+'@rsc-parser/chrome-extension': minor
+'@rsc-parser/embedded': minor
+'@rsc-parser/react-client': minor
+'@rsc-parser/storybook': minor
+'@rsc-parser/website': minor
+---
+
+Add one error boundary per tab panel in RequestDetail

--- a/packages/core/src/components/RequestDetail.tsx
+++ b/packages/core/src/components/RequestDetail.tsx
@@ -74,23 +74,31 @@ export function RequestDetail({ events }: { events: RscEvent[] }) {
           aria-busy={isPending}
           alwaysVisible={true}
         >
-          <ErrorBoundary FallbackComponent={GenericErrorBoundaryFallback}>
-            {currentTab === 'headers' ? (
+          {currentTab === 'headers' ? (
+            <ErrorBoundary FallbackComponent={GenericErrorBoundaryFallback}>
               <RequestDetailTabHeaders events={events} />
-            ) : null}
-            {currentTab === 'parsedPayload' ? (
+            </ErrorBoundary>
+          ) : null}
+          {currentTab === 'parsedPayload' ? (
+            <ErrorBoundary FallbackComponent={GenericErrorBoundaryFallback}>
               <RequestDetailTabParsedPayload events={events} />
-            ) : null}
-            {currentTab === 'rawPayload' ? (
+            </ErrorBoundary>
+          ) : null}
+          {currentTab === 'rawPayload' ? (
+            <ErrorBoundary FallbackComponent={GenericErrorBoundaryFallback}>
               <RequestDetailTabRawPayload events={events} />
-            ) : null}
-            {currentTab === 'timings' ? (
+            </ErrorBoundary>
+          ) : null}
+          {currentTab === 'timings' ? (
+            <ErrorBoundary FallbackComponent={GenericErrorBoundaryFallback}>
               <RequestDetailTabTimings events={events} />
-            ) : null}
-            {currentTab === 'network' ? (
+            </ErrorBoundary>
+          ) : null}
+          {currentTab === 'network' ? (
+            <ErrorBoundary FallbackComponent={GenericErrorBoundaryFallback}>
               <RequestDetailTabNetwork events={events} />
-            ) : null}
-          </ErrorBoundary>
+            </ErrorBoundary>
+          ) : null}
         </TabPanel>
       </div>
     </TabProvider>


### PR DESCRIPTION
Currently, if any tab panel in RequestDetail throws, then all of the other tabs will also show an error boundary.

Now I've wrapped each tab in their own error boundary instead, so that they only fail in isolation.