### PR TITLE
Don't flip recording state when running triggerReadNextJsScriptTags

### DIFF
--- a/.changeset/brave-readers-matter.md
+++ b/.changeset/brave-readers-matter.md
@@ -1,0 +1,11 @@
+---
+'@rsc-parser/chrome-extension': minor
+'@rsc-parser/embedded': minor
+'@rsc-parser/embedded-example': minor
+'@rsc-parser/core': minor
+'@rsc-parser/react-client': minor
+'@rsc-parser/storybook': minor
+'@rsc-parser/website': minor
+---
+
+Don't flip recording state when running triggerReadNextJsScriptTags

--- a/packages/chrome-extension/src/RscDevtoolsExtension.tsx
+++ b/packages/chrome-extension/src/RscDevtoolsExtension.tsx
@@ -74,7 +74,7 @@ export function RscDevtoolsExtension() {
         </>
       }
     >
-      {events.length === 0 || !isRecording ? (
+      {events.length === 0 ? (
         <ViewerStreamsEmptyState />
       ) : (
         <ViewerStreams events={events} />
@@ -157,7 +157,6 @@ function useRscEvents() {
   }, []);
 
   const triggerReadNextJsScriptTags = useCallback(() => {
-    setIsRecording(true);
     chrome.tabs.sendMessage(chrome.devtools.inspectedWindow.tabId, {
       type: 'READ_NEXT_JS_SCRIPT_TAGS',
       data: {

--- a/packages/embedded/RscDevtoolsPanel.tsx
+++ b/packages/embedded/RscDevtoolsPanel.tsx
@@ -108,7 +108,7 @@ export function RscDevtoolsPanel({
             </>
           }
         >
-          {events.length === 0 || !isRecording ? (
+          {events.length === 0 ? (
             <ViewerStreamsEmptyState />
           ) : (
             <ViewerStreams events={events} />
@@ -205,7 +205,6 @@ function useRscEvents() {
       return;
     }
 
-    setIsRecording(true);
     startTransition(() => {
       setEvents((previousEvents) => [...previousEvents, ...events]);
     });


### PR DESCRIPTION
Previously, when running, triggerReadNextJsScriptTags, `setIsRecording(true);` would be called. This made the UI look like it was recording, but it actually wasn't, so navigating around didn't yield any additional captured requests.

Now, `setIsRecording(true)` won't be called, and the UI will not be in a false recording state anymore. You'll have to turn on recording yourself.