### PR TITLE
Properly externalize react in the core and embedded packages

### DIFF
--- a/.changeset/sharp-ears-jam.md
+++ b/.changeset/sharp-ears-jam.md
@@ -1,0 +1,11 @@
+---
+'@rsc-parser/embedded': patch
+'@rsc-parser/core': patch
+'@rsc-parser/embedded-example': patch
+'@rsc-parser/chrome-extension': patch
+'@rsc-parser/react-client': patch
+'@rsc-parser/storybook': patch
+'@rsc-parser/website': patch
+---
+
+Properly externalize react in the core and embedded packages

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -26,16 +26,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library
-      external: ['react', 'react-dom'],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          react: 'React',
-        },
-      },
+      external: ['react', 'react/jsx-runtime', 'react-dom'],
     },
     minify: false,
   },

--- a/packages/embedded/vite.config.ts
+++ b/packages/embedded/vite.config.ts
@@ -19,15 +19,8 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library
-      external: ['react', 'react-dom'],
+      external: ['react', 'react/jsx-runtime', 'react-dom'],
       output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          react: 'React',
-        },
         preserveModules: true,
       },
       plugins: [preserveDirectives()],


### PR DESCRIPTION
# What
- Added `react/jsx-runtime` to `rollupOptions.external` in core and embedded.
- Removed `rollupOptions.output.globals` that didn't have any effect.

# Why
It's needed to avoid bundling parts of React that are version-dependent.