### PR TITLE
Add support for rendering console chunks

### DIFF
--- a/.changeset/social-owls-wink.md
+++ b/.changeset/social-owls-wink.md
@@ -1,0 +1,11 @@
+---
+'@rsc-parser/react-client': minor
+'@rsc-parser/core': minor
+'@rsc-parser/embedded-example': minor
+'@rsc-parser/chrome-extension': minor
+'@rsc-parser/embedded': minor
+'@rsc-parser/storybook': minor
+'@rsc-parser/website': minor
+---
+
+Link to debug info references

--- a/packages/core/src/components/FlightResponseChunkDebugInfo.stories.tsx
+++ b/packages/core/src/components/FlightResponseChunkDebugInfo.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { FlightResponseChunkDebugInfo } from './FlightResponseChunkDebugInfo';
+
+const meta: Meta<typeof FlightResponseChunkDebugInfo> = {
+  component: FlightResponseChunkDebugInfo,
+};
+
+export default meta;
+type Story = StoryObj<typeof FlightResponseChunkDebugInfo>;
+
+export const WarnExample: Story = {
+  args: {
+    data: {
+      $$type: 'reference',
+      id: 'd',
+      identifier: '',
+      type: 'Debug info',
+    },
+  },
+};

--- a/packages/core/src/components/FlightResponseChunkDebugInfo.tsx
+++ b/packages/core/src/components/FlightResponseChunkDebugInfo.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
 import { DebugInfoChunk } from '@rsc-parser/react-client';
+import { FlightResponseChunkModel } from './FlightResponseChunkModel';
 
 export function FlightResponseChunkDebugInfo({
   data,
+  onClickID,
 }: {
   data: DebugInfoChunk['value'];
+  onClickID: (id: string) => void;
 }) {
-  return <p>React component name: {data.name}</p>;
+  return (
+    <FlightResponseChunkModel
+      key={JSON.stringify(data)}
+      data={data}
+      onClickID={onClickID}
+    />
+  );
 }

--- a/packages/core/src/components/RequestDetailTabParsedPayload.tsx
+++ b/packages/core/src/components/RequestDetailTabParsedPayload.tsx
@@ -324,7 +324,14 @@ function ChunkTabPanelExplorer({
     case 'text':
       return <FlightResponseChunkText data={chunk.value} />;
     case 'debugInfo':
-      return <FlightResponseChunkDebugInfo data={chunk.value} />;
+      return (
+        <FlightResponseChunkDebugInfo
+          data={chunk.value}
+          onClickID={(id) => {
+            selectTabByID(id);
+          }}
+        />
+      );
     case 'console': {
       return (
         <FlightResponseChunkConsole


### PR DESCRIPTION
Debug info is just a reference to an object. Now it links to it properly.

<img width="173" alt="image" src="https://github.com/user-attachments/assets/3d15a682-f6d0-47d6-94f8-aff5ed119155" />
